### PR TITLE
Enable nested-virt for all VM cache-images

### DIFF
--- a/cache_images/gce.yml
+++ b/cache_images/gce.yml
@@ -38,6 +38,10 @@ builders:
         src: '{{ build_name }}-b{{user `IMG_SFX` }}'
       ssh_username: packer  # arbitrary, packer will create & setup
       ssh_pty: 'true'
+      # Required to enable nested-virtualization when using this image (later)
+      # N/B: Requires `enable_nested_virtualization: true` in .cirrus.yml
+      # gce_instance block.  This sets CPU Type >= Intel Haswell (GCE requirement)
+      image_licenses: ["projects/vm-options/global/licenses/enable-vmx"]
 
     - <<: *gce_hosted_image
       name: 'prior-ubuntu'  # setup script derrived from string before "-"


### PR DESCRIPTION
Ref:
https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances

Important Note:  In order to satisfy the >= "Intel Haswell" requirement,
the `enable_nested_virtualization` attribute must be set `true` in the
relevant `gce_instance` block of a Cirrus-CI task.  This is not
documented anywhere I could find, as of this commit.

Signed-off-by: Chris Evich <cevich@redhat.com>