### PR TITLE
Fix bad ubuntu repos on reboot

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -127,6 +127,9 @@ ubuntu_finalize() {
     set -x
     $SUDO apt-get -qq -y autoremove
     $SUDO rm -rf /var/cache/apt
+    # cloud-init will re-populate these next boot, otherwise use defaults
+    $SUDO cp /usr/share/doc/apt/examples/sources.list /etc/apt/sources.list
+    $SUDO apt-get -qq -y update
     common_finalize
 }
 


### PR DESCRIPTION
Occasionally for some unknown reason, when booting a base-image to make
a cache-image, the configured apt repositories no-longer function.
Returning errors such as:

```
E: Failed to fetch
http://us-central1.gce.archive.ubuntu.com/ubuntu/dists/eoan/universe/cnf/Commands-amd64
lzma_read: Read error (7)
E: Some index files failed to download. They have been ignored, or old ones used instead.
<exit 100>
```

As /etc/apt/sources.list (containing the above repo) is setup by
cloud-init, attempt to fix the problem by restoring the default sources
list.  This should allow either:

1) cloud-init to configure future-functional sources
2) Fall back to the default distro-configured (upstream) sources.

Signed-off-by: Chris Evich <cevich@redhat.com>