### PR TITLE
Use fixed-version of BATS

### DIFF
--- a/cache_images/fedora_packaging.sh
+++ b/cache_images/fedora_packaging.sh
@@ -32,7 +32,6 @@ INSTALL_PACKAGES=(\
     autoconf
     automake
     bash-completion
-    bats
     bridge-utils
     btrfs-progs-devel
     buildah

--- a/cache_images/ubuntu_packaging.sh
+++ b/cache_images/ubuntu_packaging.sh
@@ -34,7 +34,6 @@ INSTALL_PACKAGES=(\
     autoconf
     automake
     bash-completion
-    bats
     bison
     btrfs-progs
     build-essential


### PR DESCRIPTION
Due to bug https://bugs.launchpad.net/ubuntu/+source/bats/+bug/1882542
which also affects setting things like `$IFS` a fixed version of Bats
is installed from source.  This is done using the containers/podman
Makefile, `install.tools` target for ease of maintenance.

See also: https://github.com/containers/podman/pull/6515

Signed-off-by: Chris Evich <cevich@redhat.com>