### PR TITLE
Re-implement image life-cycle management

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@ gcp_credentials: ENCRYPTED[823fdbc2fee3c27fa054ba1e9cfca084829b5e71572f1703a28e0
 
 timeout_in: 60m
 
-task:
+validate_task:
     name: "Validate"
     alias: "validate"
     timeout_in: 5m
@@ -35,11 +35,9 @@ task:
         - "make base_images/gce.json"
 
 
-task:
+image_builder_task:
     name: "Image-builder image"
     alias: "image_builder"
-    # Usable images are produced from PRs, not merges.
-    only_if: $CIRRUS_PR =~ '.+'
     depends_on:
         - validate
     # Packer needs time to clean up partially created VM images
@@ -47,20 +45,20 @@ task:
     stateful: true
     timeout_in: 30m
     container:
-      dockerfile: "image_builder/Containerfile"
-      cpu: 2
-      memory: "2G"
+        dockerfile: "image_builder/Containerfile"
+        cpu: 2
+        memory: "2G"
     script: "ci/make_image_builder.sh"
     manifest_artifacts:
         path: image_builder/manifest.json
         type: application/json
 
 
-task:
+container_images_task: &container_images
+    name: "Build container images"
     alias: "container_images"
     depends_on:
         - image_builder
-    only_if: $CIRRUS_PR =~ '.+'
     timeout_in: 30m
     gce_instance: &ibi_vm
         image_project: "libpod-218412"
@@ -91,20 +89,31 @@ task:
             DEST_FQIN: *fqin
         - name: *name
           env:
+            TARGET_NAME: 'imgobsolete'
+            DEST_FQIN: *fqin
+        - name: *name
+          env:
             TARGET_NAME: 'imgprune'
             DEST_FQIN: *fqin
     env:
         TEMPDIR: '$CIRRUS_WORKING_DIR'
         LOGIN_CMD: ENCRYPTED[d15806d68c90cf74faca59bc4f81ada269538092b8449c7d8cd4cf44cd8d58a7482d2b249a9da06508f32f9e4075dc18]
-    script: "ci/make_container_images.sh"
-    container_artifacts:
-        path: '*.tar'
-        type: 'application/x-tar'
+    # CIRRUS_BRANCH *is* none-empty for both pr-push and branch-push
+    # Only push 'latest' tag images during a branch-push
+    script: |
+        if [[ -n "$CIRRUS_PR" ]]; then
+            ci/make_container_images.sh;
+        elif [[ -z "$CIRRUS_CRON" ]] && [[ -z "$CIRRUS_TAG" ]]; then
+            env PUSH_LATEST=1 ci/make_container_images.sh;
+        else
+            echo "No-op for cron and tag-push triggered builds";
+        fi
 
 
-task:
+base_images_task:
+    name: "Build VM Base-images"
     alias: "base_images"
-    only_if: $CIRRUS_PR =~ '.+'
+    only_if: &is_pr $CIRRUS_PR != ''
     depends_on:
         - image_builder
     # Packer needs time to clean up partially created VM images
@@ -137,9 +146,11 @@ task:
         path: base_images/manifest.json
         type: application/json
 
-task:
+
+cache_images_task:
+    name: "Build VM Cache-images"
     alias: "cache_images"
-    only_if: $CIRRUS_PR =~ '.+'
+    only_if: *is_pr
     depends_on:
         - base_images
     # Packer needs time to clean up partially created VM images
@@ -147,10 +158,9 @@ task:
     stateful: true
     timeout_in: 40m
     container:
-      dockerfile: "image_builder/Containerfile"
-      cpu: 2
-      memory: "2G"
-    script: "ci/make_cache_images.sh"
+        dockerfile: "image_builder/Containerfile"
+        cpu: 2
+        memory: "2G"
     matrix:
         - &cache_image
           name: "${PACKER_BUILDS} Cache Image"
@@ -165,11 +175,100 @@ task:
         - <<: *cache_image
           env:
             PACKER_BUILDS: "prior-ubuntu"
+    script: "ci/make_cache_images.sh"
     manifest_artifacts:
         path: cache_images/manifest.json
         type: application/json
 
-task:
+
+# Test both metadata addition to newly built images, and ensure container functions
+imgts_task:
+    name: "Apply new image metadata"
+    alias: imgts
+    only_if: *is_pr
+    depends_on:
+        - container_images
+        - base_images
+        - cache_images
+    container:
+        image: 'quay.io/libpod/imgts:c$IMG_SFX'
+        cpu: 2
+        memory: '2G'
+    env:
+        BUILDID: "$CIRRUS_BUILD_ID"
+        REPOREF: "$CIRRUS_REPO_NAME"
+        GCPJSON: ENCRYPTED[112c55192dba9a7edd1889a7e704aa1e6ae40730b97ad8ebcbae2bb5f4ff84c7e9ca5b955baaf1f69e7b9e5c5a14a4d3]
+        GCPNAME: ENCRYPTED[93cad237544dbbd663874e6896cd9c50a708e87d2cd40724c8b6c18237f4e2d40fd5e3c4a1fdbf7dafac3ceadf69a1c1]
+        GCPPROJECT: 'libpod-218412'
+        IMGNAMES: |
+            image-builder-${IMG_SFX}
+            fedora-b${IMG_SFX}
+            prior-fedora-b${IMG_SFX}
+            ubuntu-b${IMG_SFX}
+            prior-ubuntu-b${IMG_SFX}
+            fedora-c${IMG_SFX}
+            prior-fedora-c${IMG_SFX}
+            ubuntu-c${IMG_SFX}
+            prior-ubuntu-c${IMG_SFX}
+    script: "/usr/local/bin/entrypoint.sh"
+
+
+test_imgobsolete_task: &lifecycle_test
+    name: "Test old images obsolete marking"
+    alias: test_imgobsolete
+    only_if: *is_pr
+    depends_on:
+        - imgts
+    container:
+        image: 'quay.io/libpod/imgobsolete:c$IMG_SFX'
+        cpu: 2
+        memory: '2G'
+    env: &lifecycle_env
+        GCPJSON: ENCRYPTED[a0482ce379d4fa3ea84b3fd6199cce75294262a65250c08ec9a5c454cbba06b7b55c8cdb43bbab2f6a81f3419096200e]
+        GCPNAME: ENCRYPTED[57b2c60b8168a2dc6f281a31a051ffab069b3c05bd495f38c0d5178fdcfb9ac7e1295460d8c4beb979c88d88061fa463]
+        GCPPROJECT: 'libpod-218412'
+        DRY_RUN: 1
+    script:  /usr/local/bin/entrypoint.sh;
+
+
+test_imgprune_task:
+    <<: *lifecycle_test
+    name: "Test obsolete image deletion"
+    alias: test_imgprune
+    depends_on:
+        - test_imgobsolete
+    container:
+        image: 'quay.io/libpod/imgprune:c$IMG_SFX'
+
+
+# N/B: "latest" image produced after PR-merge (branch-push)
+cron_imgobsolete_task: &lifecycle_cron
+    name: "Periodicly mark old images obsolete"
+    alias: cron_imgobsolete
+    only_if: $CIRRUS_PR == '' && $CIRRUS_CRON != ''
+    depends_on:
+        - container_images
+    container:
+        image: 'quay.io/libpod/imgobsolete:latest'
+        cpu: 2
+        memory: '2G'
+    env:
+        <<: *lifecycle_env
+        DRY_RUN: 0
+    script:  /usr/local/bin/entrypoint.sh;
+
+
+cron_imgprune_task:
+    <<: *lifecycle_cron
+    name: "Periodicly delete obsolete images"
+    alias: cron_imgprune
+    depends_on:
+        - cron_imgobsolete
+    container:
+        image: 'quay.io/libpod/imgprune:latest'
+
+
+success_task:
     name: &success_name success
     alias: *success_name
     depends_on:
@@ -178,6 +277,11 @@ task:
         - container_images
         - base_images
         - cache_images
+        - imgts
+        - test_imgobsolete
+        - cron_imgobsolete
+        - test_imgprune
+        - cron_imgprune
     container:
         <<: *ci_container
     clone_script: mkdir -p "${CIRRUS_WORKING_DIR}"  # source is not needed

--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,14 @@ $(_TEMPDIR)/imgts.tar: imgts/Containerfile imgts/entrypoint.sh imgts/google-clou
 	rm -f $@
 	podman save --quiet -o $@ imgts:$(IMG_SFX)
 
+imgobsolete: $(_TEMPDIR)/imgobsolete.tar  ## Build the VM Image obsoleting container image
+$(_TEMPDIR)/imgobsolete.tar: $(_TEMPDIR)/imgts.tar imgts/lib_entrypoint.sh imgobsolete/Containerfile imgobsolete/entrypoint.sh $(_TEMPDIR)
+	podman load -i $(_TEMPDIR)/imgts.tar imgts:latest
+	podman build -t imgobsolete:$(call err_if_empty,IMG_SFX) \
+		-f imgobsolete/Containerfile .
+	rm -f $@
+	podman save --quiet -o $@ imgobsolete:$(IMG_SFX)
+
 imgprune: $(_TEMPDIR)/imgprune.tar  ## Build the VM Image pruning container image
 $(_TEMPDIR)/imgprune.tar: $(_TEMPDIR)/imgts.tar imgts/lib_entrypoint.sh imgprune/Containerfile imgprune/entrypoint.sh $(_TEMPDIR)
 	podman load -i $(_TEMPDIR)/imgts.tar imgts:latest

--- a/imgobsolete/Containerfile
+++ b/imgobsolete/Containerfile
@@ -3,7 +3,7 @@ FROM imgts:latest
 RUN yum -y update && \
     yum clean all
 
-COPY /imgprune/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY /imgobsolete/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod 755 /usr/local/bin/entrypoint.sh
 
 # These are only needed by imgts

--- a/imgobsolete/README.md
+++ b/imgobsolete/README.md
@@ -1,0 +1,13 @@
+A container image for maintaining the collection of
+VM images used by CI/CD on several projects. Acts upon
+metadata maintained by the `imgts` container.  Images
+found to be disused, are marked obsolete (deprecated).
+A future process is responsible for pruning the obsolete
+images.  This workflow provides for a recovery option
+should an image be erroneously obsoleted.
+
+Example build (from repository root):
+
+```bash
+podman build -t $IMAGE_NAME -f imgobsolete/Containerfile .
+```

--- a/imgobsolete/entrypoint.sh
+++ b/imgobsolete/entrypoint.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# This script is set as, and intended to run as the `imgobsolete` container's
+# entrypoint.  It searches for non-deprecated VM images with missing/invalid
+# metadata and those with an "old" `last-used` timestamp.  Some number of
+# these images are randomly selected and made obsolete.   They are also
+# marked with deletion-metadata some time in the future.
+
+set -e
+
+# shellcheck source=imgts/lib_entrypoint.sh
+source /usr/local/bin/lib_entrypoint.sh
+
+req_env_var GCPJSON GCPNAME GCPPROJECT
+
+gcloud_init
+
+# Set this to 1 for testing
+DRY_RUN="${DRY_RUN:-0}"
+OBSOLETE_LIMIT=10
+THEFUTURE=$(date --date='+1 hour' +%s)
+TOO_OLD='30 days ago'
+THRESHOLD=$(date --date="$TOO_OLD" +%s)
+# Format Ref: https://cloud.google.com/sdk/gcloud/reference/topic/formats
+FORMAT='value[quote](name,selfLink,creationTimestamp,status,labels)'
+# Required variable set by caller
+# shellcheck disable=SC2154
+PROJRE="/v1/projects/$GCPPROJECT/global/"
+# Filter Ref: https://cloud.google.com/sdk/gcloud/reference/topic/filters
+# shellcheck disable=SC2154
+FILTER="selfLink~$PROJRE AND creationTimestamp<$(date --date="$TOO_OLD" --iso-8601=date)"
+TOOBSOLETE=$(mktemp -p '' toobsolete.XXXXXX)
+
+msg "Searching images for candidates using filter:${NOR} $FILTER"
+# Ref: https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#deprecating_an_image
+$GCLOUD compute images list --format="$FORMAT" --filter="$FILTER" | \
+    while read name selfLink creationTimestamp status labels
+    do
+        count_image
+        reason=""
+        created_ymd=$(date --date=$creationTimestamp --iso-8601=date)
+        last_used=$(egrep --only-matching --max-count=1 'last-used=[[:digit:]]+' <<< $labels || true)
+
+        LABELSFX="labels: '$labels'"
+
+        # No label was set
+        if [[ -z "$last_used" ]]
+        then # image lacks any tracking labels
+            reason="Missing 'last-used' metadata; $LABELSFX"
+            echo "$name $reason" >> $TOOBSOLETE
+            continue
+        fi
+
+        last_used_timestamp=$(date --date=@$(cut -d= -f2 <<< $last_used || true) +%s || true)
+        last_used_ymd=$(date --date=@$last_used_timestamp --iso-8601=date)
+        # Validate label contents
+        if [[ -z "$last_used_timestamp" ]] || \
+           [[ "$last_used_timestamp" -ge "$THEFUTURE" ]]
+        then
+            reason="Missing/invalid last-used timestamp: '$last_used_timestamp'; $LABELSFX"
+            echo "$name $reason" >> $TOOBSOLETE
+            continue
+        fi
+
+        # Image is actually too old
+        if [[ "$last_used_timestamp" -le $THRESHOLD ]]
+        then
+            reason="Used over $TOO_OLD on $last_used_ymd; $LABELSFX"
+            echo "$name $reason" >> $TOOBSOLETE
+            continue
+        fi
+
+        msg "Retaining $name | $created_ymd | $status | $labels"
+    done
+
+COUNT=$(<"$IMGCOUNT")
+msg "########################################################################"
+msg "Obsoleting $OBSOLETE_LIMIT random images of $COUNT examined:"
+
+# Require a minimum number of images to exist
+if [[ "$COUNT" -lt $OBSOLETE_LIMIT ]]
+then
+    die 0 "Safety-net Insufficient images ($COUNT) to process ($OBSOLETE_LIMIT required)"
+fi
+
+sort --random-sort $TOOBSOLETE | tail -$OBSOLETE_LIMIT | \
+    while read -r image_name reason; do
+
+    msg "Obsoleting $image_name:${NOR} $reason"
+    if ((DRY_RUN)); then
+        msg "Dry-run: No changes made"
+    else
+        # Ref: https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#deprecating_an_image
+        $GCLOUD compute images deprecate $image_name --state=OBSOLETE --delete-in=30d
+    fi
+done

--- a/imgprune/README.md
+++ b/imgprune/README.md
@@ -1,6 +1,7 @@
 A container image for maintaining the collection of
-VM images used by CI/CD on several projects. Acts upon
-metadata maintained by the imgts container.
+deprecated VM images disused by CI/CD projects.  Images
+marked deprecated are pruned (deleted) by this image
+once they surpass a certain age since last-used.
 
 Example build (from repository root):
 

--- a/imgts/entrypoint.sh
+++ b/imgts/entrypoint.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# This script is set as, and intended to run as the `imgts` container's
+# entrypoint. It's purpose is to operate on a list of VM Images, adding
+# metadata to each.  It must be executed alongside any repository's
+# automation, which produces or uses GCP VM Images.
+
 set -e
 
 # shellcheck source=./lib_entrypoint.sh
@@ -20,9 +25,21 @@ ARGS="
 
 # Must be defined by the cirrus-ci job using the container
 # shellcheck disable=SC2154
+[[ -n "$IMGNAMES" ]] || \
+    die 1 "No \$IMGNAMES were specified."
+
+# Don't allow one bad apple to ruin the whole batch
+ERRIMGS=''
+
+# Must be defined by the cirrus-ci job using the container
+# shellcheck disable=SC2154
 for image in $IMGNAMES
 do
-    $GCLOUD compute images update "$image" $ARGS &
+    if ! $GCLOUD compute images update "$image" $ARGS; then
+        msg "Detected update error for '$image'" > /dev/stderr
+        ERRIMGS="$ERRIMGS $image"
+    fi
 done
 
-wait || echo "Warning: No \$IMGNAMES were specified."
+[[ -z "$ERRIMGS" ]] || \
+    die 2 "ERROR: Failed to update one or more image timestamps: $ERRIMGS"


### PR DESCRIPTION
Previously, successfully updating VM image metadata was treated as
optional (errors ignored).  This resulted in unrelated failures
(e.g. auth. token expiring) going unnoticed.  Consequentially VM
images that were in-use got deleted without warning.  Fix this by
making the operations within `imgts` mandatory (do not ignore
failures).

To further protect VM images from being removed while in use, introduce
a new container image `imgobsolete`, to be run before `imgprune`.
Instead of deleting images, they will be marked as 'deprecated' and
'obsolete' by this new container.  It will also encode advisory
deletion-date metadata, set 30 days into the future.

Lastly, update the `imgprune` container image such that it only searches for
images marked 'deprecated' and 'obsolete' with a metadata deletion-date
in the past.  This greatly simplifies the script.

The new 'obsolete' image state prevents the image from being used
or listed, but does not actually remove them.  If a mistake is
noticed, the image can be recovered manually with a simple
`gcloud` command:

```
gcloud compute images deprecate <NAME> --state=ACTIVE
```

Signed-off-by: Chris Evich <cevich@redhat.com>