### PR TITLE
Remove cri-o from Ubuntu VM images

### DIFF
--- a/cache_images/ubuntu_packaging.sh
+++ b/cache_images/ubuntu_packaging.sh
@@ -120,7 +120,6 @@ INSTALL_PACKAGES=(\
 # Download these package files, but don't install them; Any tests
 # wishing to, may install them using their native tools at runtime.
 DOWNLOAD_PACKAGES=(\
-    "cri-o-$(get_kubernetes_version)"
     cri-tools
     parallel
 )

--- a/lib.sh
+++ b/lib.sh
@@ -87,10 +87,6 @@ get_kubernetes_version() {
             KUBERNETES_VERSION="1.15" ;;
         fedora-33)
             KUBERNETES_VERSION="1.18" ;;
-        ubuntu-19)
-            KUBERNETES_VERSION="1.15" ;;
-        ubuntu-20)
-            KUBERNETES_VERSION="1.15" ;;
         *) die "Unknown/Unsupported \$OS_REL_VER '$OS_REL_VER'"
     esac
     echo "$KUBERNETES_VERSION"


### PR DESCRIPTION
Conmon testing (the only consumer of the cri-o package) only
tests Fedora, there is no need for this package to be present on Ubuntu
VMs.  Remove it to reduce future maintenance burden.

Signed-off-by: Chris Evich <cevich@redhat.com>