### PR TITLE
Include package needed for c/storage testing

### DIFF
--- a/cache_images/fedora_packaging.sh
+++ b/cache_images/fedora_packaging.sh
@@ -103,6 +103,7 @@ INSTALL_PACKAGES=(\
     openssl-devel
     ostree-devel
     pandoc
+    parallel
     pkgconfig
     podman
     procps-ng

--- a/cache_images/ubuntu_packaging.sh
+++ b/cache_images/ubuntu_packaging.sh
@@ -103,6 +103,7 @@ INSTALL_PACKAGES=(\
     make
     netcat
     openssl
+    parallel
     pkg-config
     podman
     protobuf-c-compiler


### PR DESCRIPTION
Including this allows c/storage testing to operate w/o
installing/upgrading packages at runtime.  This is desired
as it (generally) improves reliability.

Signed-off-by: Chris Evich <cevich@redhat.com>