### PR TITLE
Update packages on Fedora again, after installing

### DIFF
--- a/cache_images/fedora_packaging.sh
+++ b/cache_images/fedora_packaging.sh
@@ -184,6 +184,9 @@ if [[ ${#DOWNLOAD_PACKAGES[@]} -gt 0 ]]; then
     lilto ooe.sh $SUDO dnf download -y --resolve "${DOWNLOAD_PACKAGES[@]}"
 fi
 
+# It was observed in F33, dnf install doesn't always get you the latest/greatest
+lilto $SUDO dnf update -y
+
 echo "Configuring Go environment"
 export GOPATH=/var/tmp/go
 mkdir -p "$GOPATH"


### PR DESCRIPTION
It was observed in freshly built F33 VM images, dnf install doesn't
always get you the latest/greatest packages.  Fix this with a big-
hammer (I don't understand the problem) by running a second package
update after installing.

Signed-off-by: Chris Evich <cevich@redhat.com>