### PR TITLE
[CI:LATEST] Update automation library to 2.1.3

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -24,7 +24,7 @@ CUSTOM_CLOUD_CONFIG_DEFAULTS="$SCRIPT_DIRPATH/cloud-init/$OS_RELEASE_ID/cloud.cf
 # This location is checked by automation in other repos, please do not change.
 PACKAGE_DOWNLOAD_DIR=/var/cache/download
 
-INSTALL_AUTOMATION_VERSION="2.1.2"
+INSTALL_AUTOMATION_VERSION="2.1.3"
 
 PUSH_LATEST="${PUSH_LATEST:-0}"
 


### PR DESCRIPTION
Required for get_ci_vm support of `macos_instance` type.

Signed-off-by: Chris Evich <cevich@redhat.com>