### PR TITLE
EXPERIMENTAL: Switch to using kickstart for Fedora base images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,10 @@ image_builder/manifest.json: image_builder/gce.json image_builder/setup.sh lib.s
 .PHONY: image_builder_debug
 image_builder_debug: $(_TEMPDIR)/image_builder_debug.tar ## Build and enter container for local development/debugging of targets requiring packer + virtualization
 	/usr/bin/podman run -it --rm \
-		--security-opt label=disable -v $$HOME:$$HOME -w $(_MKFILE_DIR) \
+		--security-opt label=disable \
+		--expose=5900-6000 \
+		--publish-all \
+		-v $$HOME:$$HOME -w $(_MKFILE_DIR) \
 		-v $(_TEMPDIR):$(_TEMPDIR):Z \
 		-v $(call err_if_empty,GAC_FILEPATH):$(GAC_FILEPATH):Z \
 		-v /dev/kvm:/dev/kvm \

--- a/base_images/fedora/ks.cfg
+++ b/base_images/fedora/ks.cfg
@@ -1,0 +1,89 @@
+# Borrowed heavily from '/root/original-ks.cfg' inside
+# https://dl.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/Fedora-Cloud-Base-34-1.2.x86_64.qcow2
+
+# Keyboard layouts
+keyboard 'us'
+
+# Root password
+rootpw --iscrypted --lock locked
+
+# System language
+lang en_US.UTF-8
+
+# Reboot after installation
+reboot
+
+# Use text mode install
+text
+
+# Firewall configuration
+firewall --disabled
+timezone Etc/UTC --utc
+
+# Network installation
+url --url="https://dl.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/os/"
+
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --enabled="sshd,cloud-init,cloud-init-local,cloud-config,cloud-final"
+
+# System bootloader configuration
+bootloader --append="no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8" --location=mbr --timeout=1
+
+# Clear the Master Boot Record
+zerombr
+
+# Partition clearing information
+clearpart --all
+
+autopart --type=plain --fstype=xfs --nohome --noboot --noswap
+
+%packages --inst-langs=en
+@^cloud-server-environment
+kernel-core
+qemu-guest-agent
+-dracut-config-rescue
+-firewalld
+-geolite2-city
+-geolite2-country
+-kernel
+-plymouth
+-zram-generator-defaults
+%end
+
+%post --erroronfail
+# linux-firmware is installed by default and is quite large. As of mid 2020:
+#   Total download size: 97 M
+#   Installed size: 268 M
+# So far we've been fine shipping without it so let's continue.
+# More discussion about this in #1234504.
+echo "Removing linux-firmware package."
+rpm -e linux-firmware
+
+# See the systemd-random-seed.service man page that says:
+#   " It is recommended to remove the random seed from OS images intended
+#     for replication on multiple systems"
+echo "Removing random-seed so it's not the same in every image."
+rm -f /var/lib/systemd/random-seed
+
+echo "Import RPM GPG key"
+releasever=$(rpm --eval '%{fedora}')
+basearch=$(uname -i)
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+
+echo "Zeroing out empty space."
+# This forces the filesystem to reclaim space from deleted files
+dd bs=1M if=/dev/zero of=/var/tmp/zeros || :
+rm -f /var/tmp/zeros
+echo "(Don't worry -- that out-of-space error was expected.)"
+
+# When we build the image a networking config file gets left behind.
+# Let's clean it up.
+echo "Cleanup leftover networking configuration"
+rm -f /etc/NetworkManager/system-connections/*.nmconnection
+
+# Clear machine-id on pre generated images
+truncate -s 0 /etc/machine-id
+%end

--- a/base_images/gce.yml
+++ b/base_images/gce.yml
@@ -22,12 +22,12 @@ variables:  # Empty value means it must be passed in on command-line
     PRIOR_UBUNTU_BASE_IMAGE: 'ubuntu-2010-groovy-v20210325'
 
     # Latest Fedora release download URL
-    FEDORA_IMAGE_URL: "https://dl.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/Fedora-Cloud-Base-34-1.2.x86_64.qcow2"
-    FEDORA_CSUM_URL: "https://dl.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/Fedora-Cloud-34-1.2-x86_64-CHECKSUM"
+    FEDORA_IMAGE_URL: "https://dl.fedoraproject.org/pub/fedora/linux/releases/34/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-34-1.2.iso"
+    FEDORA_CSUM_URL: "https://dl.fedoraproject.org/pub/fedora/linux/releases/34/Everything/x86_64/iso/Fedora-Everything-34-1.2-x86_64-CHECKSUM"
 
     # Prior Fedora release
-    PRIOR_FEDORA_IMAGE_URL: "https://dl.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2"
-    PRIOR_FEDORA_CSUM_URL: "https://dl.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-33-1.2-x86_64-CHECKSUM"
+    PRIOR_FEDORA_IMAGE_URL: "https://dl.fedoraproject.org/pub/fedora/linux/releases/33/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-33-1.2.iso"
+    PRIOR_FEDORA_CSUM_URL: "https://dl.fedoraproject.org/pub/fedora/linux/releases/33/Everything/x86_64/iso/Fedora-Everything-33-1.2-x86_64-CHECKSUM"
 
 
 # Don't leak sensitive values in error messages / output
@@ -41,13 +41,24 @@ builders:
       accelerator: "kvm"
       qemu_binary: '/usr/libexec/qemu-kvm'  # Unique to CentOS, not fedora :(
       iso_url: '{{user `FEDORA_IMAGE_URL`}}'
-      disk_image: true
       format: "raw"
       disk_size: 10240
       iso_checksum: 'file:{{user `FEDORA_CSUM_URL`}}'
       vm_name: "disk.raw"  # actually qcow2, name required for post-processing
       output_directory: '{{ user `TEMPDIR` }}/{{build_name}}' # /<vm_name>.disk.raw
       boot_wait: '5s'
+      boot_command:
+        - '<up>'  # Test & Install (second option) always the default
+        - '<tab>' # Drop to the end of 'boot: <kernel command line>'
+        - ' ' # Append options to the end of the line
+        - 'noshell'
+        - ' '
+        - 'inst.singlelang'
+        - ' '
+        - 'inst.cmdline'
+        - ' '
+        - 'inst.ks=cdrom'
+        - '<enter>'
       shutdown_command: 'shutdown -h now'
       headless: true
       # qemu_binary: "/usr/libexec/qemu-kvm"
@@ -68,12 +79,13 @@ builders:
       cd_files:
         - '{{user `TEMPDIR`}}/meta-data'
         - '{{user `TEMPDIR`}}/user-data'
+        - './base_images/{{build_name}}/ks.cfg'
+      vnc_bind_address: '127.0.0.1'
       communicator: 'ssh'
-      pause_before_connecting: '10s'
       ssh_private_key_file: '{{ user `TEMPDIR` }}/cidata.ssh'
       ssh_disable_agent_forwarding: true
       ssh_username: 'root'
-      ssh_timeout: '5m'
+      ssh_timeout: '30m'  # Time for kickstart to finish and reboot
       vnc_bind_address: 0.0.0.0
 
     - <<: *qemu_virt

--- a/base_images/prior-fedora/ks.cfg
+++ b/base_images/prior-fedora/ks.cfg
@@ -1,0 +1,1 @@
+../fedora/ks.cfg


### PR DESCRIPTION
This is required to change the root filesystem type.  The current
(F33/F34) default for cloud images is ext4, but XFS is desired for
testing.

Signed-off-by: Chris Evich <cevich@redhat.com>