### PR TITLE
[CI:TOOLING] orphanvms: trigger on start instead of create time

### DIFF
--- a/.github/workflows/orphan_vms.yml
+++ b/.github/workflows/orphan_vms.yml
@@ -8,8 +8,8 @@ name: check_orphan_vms
 on:
     # Note: This only applies to the default branch.
     schedule:
-        # Assume cirrus cron jobs runs at least once per day
-        - cron:  '59 23 * * *'
+        # Nobody is around to respond to weekend e-mails
+        - cron:  '59 23 * * 0-4'
     # Debug: Allow triggering job manually in github-actions WebUI
     workflow_dispatch: {}
 

--- a/orphanvms/entrypoint.sh
+++ b/orphanvms/entrypoint.sh
@@ -14,13 +14,14 @@ req_env_var GCPJSON GCPNAME GCPPROJECTS
 # Try not to make any output when no orphan VMs are found
 GCLOUD="$GCLOUD --quiet --verbosity=error"
 EVERYTHING=${EVERYTHING:-0}  # set to '1' for testing
-TOO_OLD='3 days ago'
+TOO_OLD='3 days ago'  # Detect Friday Orphans on Monday
 NOW=$(date +%s)
-THRESHOLD=$(date --date="$TOO_OLD" +%s)
+THRESHOLD=$(date --date="$TOO_OLD" --iso-8601=minute)
 # Format Ref: https://cloud.google.com/sdk/gcloud/reference/topic/formats
-FORMAT='value[quote](name,creationTimestamp,labels)'
+FORMAT='value[quote](name,lastStartTimestamp,labels)'
 # Filter Ref: https://cloud.google.com/sdk/gcloud/reference/topic/filters
-FILTER="status!=TERMINATED AND creationTimestamp<$(date --date="$TOO_OLD" --iso-8601=date)"
+# List fields cmd: `gcloud compute instances list --format=yaml --limit=1`
+FILTER="status!=TERMINATED AND lastStartTimestamp<$THRESHOLD"
 if ((EVERYTHING)); then
     FILTER="status:*"
 fi
@@ -34,13 +35,13 @@ for GCPPROJECT in $GCPPROJECTS; do
     echo "Orphaned $GCPPROJECT VMs:" > $OUTPUT
     # Ref: https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#deprecating_an_image
     $GCLOUD compute instances list --format="$FORMAT" --filter="$FILTER" | \
-        while read name creationTimestamp labels
+        while read name lastStartTimestamp labels
         do
-            if [[ -z "$name" ]] || [[ -z "$creationTimestamp" ]]; then continue; fi
-            created_epoch=$(date --date=$creationTimestamp +%s)
-            age_days=$((($NOW - $created_epoch) / (60 * 60 * 24)))
+            if [[ -z "$name" ]] || [[ -z "$lastStartTimestamp" ]]; then continue; fi
+            started_at=$(date --date=$lastStartTimestamp +%s)
+            age_days=$((($NOW - $started_at) / (60 * 60 * 24)))
             # running in a child-process, must buffer into file.
-            echo -e "* VM $name is $age_days days old and labeled '$labels'" >> $OUTPUT
+            echo -e "* VM $name running $age_days days with labels '$labels'" >> $OUTPUT
         done
 
     if [[ $(wc -l $OUTPUT | awk '{print $1}') -gt 1 ]]; then


### PR DESCRIPTION
There are cases where users have "play" VMs that are normally shutdown
when not in use.  The monitor was falsely triggering on them when
running, due to their very long create-time based age.  Switch to using
the start-time, which will be more accurate in all use cases.

Signed-off-by: Chris Evich <cevich@redhat.com>