### PR TITLE
Enable future use of nested VMs

### DIFF
--- a/cache_images/gce.yml
+++ b/cache_images/gce.yml
@@ -38,6 +38,8 @@ builders:
       ssh_username: packer  # arbitrary, packer will create & setup w/ temp. keypair
       ssh_pty: 'true'
       temporary_key_pair_type: ed25519
+      # Permit running nested VM's to support specialized testing
+      image_licenses: ["projects/vm-options/global/licenses/enable-vmx"]
 
     - <<: *gce_hosted_image
       name: 'prior-ubuntu'  # setup script derrived from string before "-"


### PR DESCRIPTION
This may be necessary for example, for testing out NUMA features.
Google doesn't provide any control over NUMA for VMs it provisions.

Signed-off-by: Chris Evich <cevich@redhat.com>