### PR TITLE
Implement build for Skopeo devel/CI container image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -96,9 +96,15 @@ container_images_task: &container_images
           env:
             TARGET_NAME: 'prior-ubuntu_podman'
             DEST_FQIN: *fqin
+        - name: *name
+          env:
+            TARGET_NAME: 'skopeo_cidev'
+            DEST_FQIN: *fqin
     env: &image_env
         TEMPDIR: '$CIRRUS_WORKING_DIR'
-        LOGIN_CMD: ENCRYPTED[d15806d68c90cf74faca59bc4f81ada269538092b8449c7d8cd4cf44cd8d58a7482d2b249a9da06508f32f9e4075dc18]
+        # For quay.io/libpod namespace
+        REG_USERNAME: ENCRYPTED[de755aef351c501ee480231c24eae25b15e2b2a2b7c629f477c1d427fc5269e360bb358a53bd8914605bae588e99b52a]
+        REG_PASSWORD: ENCRYPTED[52268944bb0d6642c33efb1c5d7fb82d0c40f9e6988448de35827f9be2cc547c1383db13e8b21516dbd7a0a69a7ae536]
     script: ci/make_container_images.sh;
 
 

--- a/Makefile
+++ b/Makefile
@@ -220,11 +220,8 @@ ubuntu_podman:  ## Build Ubuntu podman development container
 prior-ubuntu_podman:  ## Build Prior-Ubuntu podman development container
 	$(call build_podman_container,$@)
 
-# Workaround https://bugzilla.redhat.com/show_bug.cgi?id=1927635
-# with `--security-opt...--privileged` until bug fixed for CentOS 8.
 $(_TEMPDIR)/%_podman.tar: podman/Containerfile podman/setup.sh $(wildcard base_images/*.sh) $(wildcard cache_images/*.sh) $(_TEMPDIR) $(_TEMPDIR)/var_cache_dnf
-	buildah bud -t $*_podman:$(call err_if_empty,IMG_SFX) \
-		--security-opt seccomp=unconfined \
+	podman build -t $*_podman:$(call err_if_empty,IMG_SFX) \
 		--build-arg=BASE_NAME=$(subst prior-,,$*) \
 		--build-arg=BASE_TAG=$(call err_if_empty,BASE_TAG) \
 		--build-arg=PACKER_BUILD_NAME=$(subst _podman,,$*) \

--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,17 @@ $(_TEMPDIR)/%_podman.tar: podman/Containerfile podman/setup.sh $(wildcard base_i
 	rm -f $@
 	podman save --quiet -o $@ $*_podman:$(IMG_SFX)
 
+.PHONY: skopeo_cidev
+skopeo_cidev: $(_TEMPDIR)/skopeo_cidev.tar  ## Build Skopeo development and CI container
+
+$(_TEMPDIR)/skopeo_cidev.tar: podman/fedora_release $(wildcard skopeo_base/*) $(_TEMPDIR) $(_TEMPDIR)/var_cache_dnf
+	podman build -t skopeo_cidev:$(call err_if_empty,IMG_SFX) \
+		--build-arg=BASE_TAG=$(_fedora_podman_release) \
+		-v $(_TEMPDIR)/var_cache_dnf:/var/cache/dnf:Z \
+		skopeo_cidev
+	rm -f $@
+	podman save --quiet -o $@ skopeo_cidev:$(IMG_SFX)
+
 .PHONY: imgts
 imgts: $(_TEMPDIR)/imgts.tar  ## Build the VM image time-stamping container image
 $(_TEMPDIR)/imgts.tar: imgts/Containerfile imgts/entrypoint.sh imgts/google-cloud-sdk.repo imgts/lib_entrypoint.sh $(_TEMPDIR)

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ an overview of the process followed **by automation** to produce the
    This generated file may be ignored, *make* will be regenerate it upon
    any changes to the YAML file.
 
-4. Packer will spin up a GCE VM based on CentOS. It will then install the
+4. Packer will spin up a GCE VM based on CentOS Stream. It will then install the
    necessary packages and attach a [nested-virtualization "license" to the
    VM](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances#enablenestedvirt).  Be patient until this process completes.
 

--- a/cache_images/fedora_setup.sh
+++ b/cache_images/fedora_setup.sh
@@ -35,6 +35,11 @@ if ! ((CONTAINER)) && [[ "$PACKER_BUILD_NAME" =~ prior ]]; then
     ooe.sh $SUDO sed -re "$SEDCMD" -i /etc/default/grub
     # This is always a symlink to the correct location under /boot/...
     ooe.sh $SUDO grub2-mkconfig -o $($SUDO realpath --physical /etc/grub2.cfg)
+    # This is needed to update the /boot/loader/entries/... file to match grub
+    # config (bug?).  Discovered Jul 28, 2021 on newly build F33 images.  Never
+    # a problem before this point :(
+    ooe.sh $SUDO grubby --grub2 --update-kernel=$($SUDO grubby --default-kernel) \
+        --args="systemd.unified_cgroup_hierarchy=0"
 fi
 
 finalize

--- a/ci/make_container_images.sh
+++ b/ci/make_container_images.sh
@@ -5,7 +5,7 @@
 # of this script in any other context/environment is unlikely to
 # function as intended.
 
-set -e
+set -eo pipefail
 
 SCRIPT_FILEPATH=$(realpath "$0")
 SCRIPT_DIRPATH=$(dirname "$SCRIPT_FILEPATH")
@@ -15,24 +15,31 @@ REPO_DIRPATH=$(realpath "$SCRIPT_DIRPATH/../")
 source "$REPO_DIRPATH/lib.sh"
 
 # shellcheck disable=SC2154
-if [[ -z "$CI" ]] || [[ "$CI" != "true" ]] || [[ "$CIRRUS_CI" != "$CI" ]]; then
+if [[ "$CI" != "true" ]] || [[ "$CIRRUS_CI" != "$CI" ]]; then
     die "Unexpected \$CI='$CI' and/or \$CIRRUS_CI='$CIRRUS_CI'"
-elif [[ -z "$IMG_SFX" ]]; then
-    die "Script requires non-empty values for \$IMG_SFX='$IMG_SFX'"
-elif [[ -z "$TARGET_NAME" ]]; then
-    die "Script requiresmakefile target \$TARGET_NAME to be non-empty"
-elif [[ -z "$DEST_FQIN" ]]; then
-    die "Script requires destination FQIN \$DEST_FQIN to be non-empty"
-elif [[ $LOGIN_CMD =~ ENCRYPTED ]]; then
-    die "\$LOGIN_CMD did not get decrypted by Cirrus"
-elif [[ ${#LOGIN_CMD} -le 5 ]]; then
-    die "\$LOGIN_CMD is a ${#LOGIN_CMD}-length string; something almost certainly went wrong with Cirrus decryption"
 fi
 
-set -eo pipefail
+declare -a req_vars
+req_vars=(\
+    IMG_SFX
+    TARGET_NAME
+    DEST_FQIN
+    REG_USERNAME
+    REG_PASSWORD
+)
+for req_var in "${req_vars[@]}"; do
+    if [[ -z "${!req_var}" ]]; then
+        echo "ERROR: Required variable \$$req_var is unset or empty."
+        exit 1
+    fi
+done
+
+# These both come in from Cirrus-CI
+# shellcheck disable=SC2154
+SRC_FQIN="$TARGET_NAME:$IMG_SFX"
+
 make "$TARGET_NAME" IMG_SFX=$IMG_SFX
 
-set +x
 # Prevent pushing 'latest' images from PRs, only branches and tags
 # shellcheck disable=SC2154
 if [[ $PUSH_LATEST -eq 1 ]] && [[ -n "$CIRRUS_PR" ]]; then
@@ -40,12 +47,17 @@ if [[ $PUSH_LATEST -eq 1 ]] && [[ -n "$CIRRUS_PR" ]]; then
     PUSH_LATEST=0
 fi
 
+# Don't leave credential file sticking around anywhere
 trap "podman logout --all" EXIT INT CONT
-# Out of pure laziness, the entire command is encrypted in Cirrus-CI
-${LOGIN_CMD}
+set +x  # protect username/password values
+# These both come in from Cirrus-CI
+# shellcheck disable=SC2154
+echo "$REG_PASSWORD" | \
+    podman login --password-stdin --username "$REG_USERNAME" "$DEST_FQIN"
 
 set -x  # Easier than echo'ing out status for everything
-SRC_FQIN="$TARGET_NAME:$IMG_SFX"
+# DEST_FQIN comes in from Cirrus-CI
+# shellcheck disable=SC2154
 podman tag "$SRC_FQIN" "$DEST_FQIN"
 podman push "$DEST_FQIN"
 

--- a/image_builder/Containerfile
+++ b/image_builder/Containerfile
@@ -3,8 +3,8 @@
 # by the relevant target in the Makefile at the root of this
 # repository.
 
-ARG CENTOS_RELEASE=8
-FROM centos:${CENTOS_RELEASE}
+ARG CENTOS_RELEASE=stream8
+FROM quay.io/centos/centos:${CENTOS_RELEASE}
 ARG PACKER_VERSION
 MAINTAINER https://github.com/containers/automation_images/image_builder
 

--- a/imgts/Containerfile
+++ b/imgts/Containerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
 # Only needed for installing build-time dependencies
 COPY /imgts/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo

--- a/imgts/google-cloud-sdk.repo
+++ b/imgts/google-cloud-sdk.repo
@@ -1,3 +1,4 @@
+# From https://github.com/GoogleCloudPlatform/compute-image-packages
 [google-compute-engine]
 name=Google Compute Engine
 baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable
@@ -6,11 +7,13 @@ gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+
+# From https://cloud.google.com/sdk/docs/install#rpm
 [google-cloud-sdk]
 name=Google Cloud SDK
 baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/skopeo_cidev/Containerfile
+++ b/skopeo_cidev/Containerfile
@@ -1,0 +1,18 @@
+ARG BASE_NAME=fedora
+ARG BASE_TAG=latest
+FROM ${BASE_NAME}:${BASE_TAG}
+
+COPY /packages.txt /root/
+RUN dnf -y update && \
+    dnf -y install $(sed -r -e '/^#/d' -e '/^$/d' /root/packages.txt) && \
+    dnf -y upgrade && \
+    dnf clean all
+
+ENV REG_REPO="https://github.com/docker/distribution.git" \
+    REG_COMMIT="47a064d4195a9b56133891bbb13620c3ac83a827" \
+    REG_COMMIT_SCHEMA1="ec87e9b6971d831f0eff752ddb54fb64693e51cd" \
+    OSO_REPO="https://github.com/openshift/origin.git" \
+    OSO_TAG="v1.5.0-alpha.3"
+
+COPY /setup.sh /root/
+RUN bash /root/setup.sh

--- a/skopeo_cidev/README.md
+++ b/skopeo_cidev/README.md
@@ -1,0 +1,8 @@
+# Skopeo CI/Dev image
+
+The contents of this directory are intended to be utilized via
+the `Makefile` at the top of the repository.  Typically as
+`make skopeo_cidev IMG_SFX=<id>`.  The resultant image is utilized
+as part of the [skopeo project's](https://github.com/containers/skopeo)
+development and CI automation.  It should not be used outside
+of those contexts.

--- a/skopeo_cidev/packages.txt
+++ b/skopeo_cidev/packages.txt
@@ -1,0 +1,50 @@
+# general deps
+git
+golang
+golang-github-cpuguy83-md2man
+make
+
+# Skopeo documentation building
+btrfs-progs-devel
+device-mapper-devel
+golang
+gpgme-devel
+make
+
+# storage deps
+btrfs-progs-devel
+device-mapper-devel
+
+# gpgme bindings deps
+libassuan-devel
+gnupg
+gpgme-devel
+
+# htpasswd for system tests
+httpd-tools
+
+# OpenShift deps
+bats
+bsdtar
+device-mapper
+docker
+e2fsprogs
+ethtool
+findutils
+golint
+hostname
+iproute
+iptables
+jq
+lsof
+nmap-ncat
+openssl
+podman
+runc
+socat
+tar
+tree
+util-linux
+wget
+which
+xfsprogs

--- a/skopeo_cidev/setup.sh
+++ b/skopeo_cidev/setup.sh
@@ -1,0 +1,79 @@
+
+
+# This script is used by the Containerfile when building an image.
+# It should NEVER ever (EVER!) be used under any other circumstances
+# (nor set as executable).
+
+set -e
+
+declare -a req_vars
+req_vars=(\
+    REG_REPO
+    REG_COMMIT
+    REG_COMMIT_SCHEMA1
+    OSO_REPO
+    OSO_TAG
+)
+for req_var in "${req_vars[@]}"; do
+    if [[ -z "${!req_var}" ]]; then
+        echo "ERROR: Required variable \$$req_var is unset or empty."
+        exit 1
+    fi
+done
+
+GOPATH=$(mktemp -d -p '' ".tmp_$(basename ${BASH_SOURCE[0]})_XXXXXXXX")
+REG_GOSRC="$GOPATH/src/github.com/docker/distribution" \
+OSO_GOSRC="$GOPATH/src/github.com/openshift/origin"
+
+# All golang code built here pre-dates support of go modules
+export GO111MODULE=off
+
+# Workaround unnecessary swap-enabling shenanagains in openshift-origin build
+export OS_BUILD_SWAP_DISABLE=1
+
+# Make debugging easier
+set -x
+
+# This comes in from the Containerfile
+# shellcheck disable=SC2154
+git clone "$REG_REPO" "$REG_GOSRC"
+cd "$REG_GOSRC"
+
+# Don't pollute the environment
+(
+    # This is required to be set like this by the build system
+    export GOPATH="$PWD/Godeps/_workspace:$GOPATH"
+    # This comes in from the Containerfile
+    # shellcheck disable=SC2154
+    git checkout -q "$REG_COMMIT"
+    go build -o /usr/local/bin/registry-v2 \
+        github.com/docker/distribution/cmd/registry
+
+    # This comes in from the Containerfile
+    # shellcheck disable=SC2154
+    git checkout -q "$REG_COMMIT_SCHEMA1"
+    go build -o /usr/local/bin/registry-v2-schema1 \
+        github.com/docker/distribution/cmd/registry
+)
+
+# These come in from the Containerfile
+# shellcheck disable=SC2154
+git clone --depth 1 -b "$OSO_TAG" "$OSO_REPO" "$OSO_GOSRC"
+cd "$OSO_GOSRC"
+
+# Edit out a "go < 1.5" check which works incorrectly with go ≥ 1.10.
+sed -i -e 's/\[\[ "\${go_version\[2]}" < "go1.5" ]]/false/' ./hack/common.sh
+
+# Fix a bug in 'options' line processing of resolv.conf when an option is
+# 8 characters long.  This can happen if/when systemd-resolved adds 'trust-ad'.
+sed -i  '/== "attempts:"/s/ 8 / 9 /' vendor/github.com/miekg/dns/clientconfig.go
+
+make build
+make all WHAT=cmd/dockerregistry
+cp -a ./_output/local/bin/linux/*/* /usr/local/bin/
+cp ./images/dockerregistry/config.yml /atomic-registry-config.yml
+mkdir /registry
+
+# When script unsuccessful, leave this behind for debugging
+# Removing these two items _significantly_ reduces the image size.
+rm -rf $GOPATH $(go env GOCACHE)


### PR DESCRIPTION
This is significantly different from the podman images (used by
buildah and podman CI).  Namely, it includes several different registry
executables needed during Skopeo's integration and system-tests.
Pre-building these into a container saves developer time locally and in
waiting for changes to pass CI testing.

Also, modernize the registry server login to use the `--password-stdin`
scheme instead of encrypting the entire command-line.