### PR TITLE
Update to Centos 8 Stream + Other important fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,11 +220,8 @@ ubuntu_podman:  ## Build Ubuntu podman development container
 prior-ubuntu_podman:  ## Build Prior-Ubuntu podman development container
 	$(call build_podman_container,$@)
 
-# Workaround https://bugzilla.redhat.com/show_bug.cgi?id=1927635
-# with `--security-opt...--privileged` until bug fixed for CentOS 8.
 $(_TEMPDIR)/%_podman.tar: podman/Containerfile podman/setup.sh $(wildcard base_images/*.sh) $(wildcard cache_images/*.sh) $(_TEMPDIR) $(_TEMPDIR)/var_cache_dnf
-	buildah bud -t $*_podman:$(call err_if_empty,IMG_SFX) \
-		--security-opt seccomp=unconfined \
+	podman build -t $*_podman:$(call err_if_empty,IMG_SFX) \
 		--build-arg=BASE_NAME=$(subst prior-,,$*) \
 		--build-arg=BASE_TAG=$(call err_if_empty,BASE_TAG) \
 		--build-arg=PACKER_BUILD_NAME=$(subst _podman,,$*) \

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ an overview of the process followed **by automation** to produce the
    This generated file may be ignored, *make* will be regenerate it upon
    any changes to the YAML file.
 
-4. Packer will spin up a GCE VM based on CentOS. It will then install the
+4. Packer will spin up a GCE VM based on CentOS Stream. It will then install the
    necessary packages and attach a [nested-virtualization "license" to the
    VM](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances#enablenestedvirt).  Be patient until this process completes.
 

--- a/cache_images/fedora_setup.sh
+++ b/cache_images/fedora_setup.sh
@@ -35,6 +35,11 @@ if ! ((CONTAINER)) && [[ "$PACKER_BUILD_NAME" =~ prior ]]; then
     ooe.sh $SUDO sed -re "$SEDCMD" -i /etc/default/grub
     # This is always a symlink to the correct location under /boot/...
     ooe.sh $SUDO grub2-mkconfig -o $($SUDO realpath --physical /etc/grub2.cfg)
+    # This is needed to update the /boot/loader/entries/... file to match grub
+    # config (bug?).  Discovered Jul 28, 2021 on newly build F33 images.  Never
+    # a problem before this point :(
+    ooe.sh $SUDO grubby --grub2 --update-kernel=$($SUDO grubby --default-kernel) \
+        --args="systemd.unified_cgroup_hierarchy=0"
 fi
 
 finalize

--- a/image_builder/Containerfile
+++ b/image_builder/Containerfile
@@ -3,8 +3,8 @@
 # by the relevant target in the Makefile at the root of this
 # repository.
 
-ARG CENTOS_RELEASE=8
-FROM centos:${CENTOS_RELEASE}
+ARG CENTOS_RELEASE=stream8
+FROM quay.io/centos/centos:${CENTOS_RELEASE}
 ARG PACKER_VERSION
 MAINTAINER https://github.com/containers/automation_images/image_builder
 

--- a/imgts/Containerfile
+++ b/imgts/Containerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
 # Only needed for installing build-time dependencies
 COPY /imgts/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo

--- a/imgts/google-cloud-sdk.repo
+++ b/imgts/google-cloud-sdk.repo
@@ -1,3 +1,4 @@
+# From https://github.com/GoogleCloudPlatform/compute-image-packages
 [google-compute-engine]
 name=Google Compute Engine
 baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable
@@ -6,11 +7,13 @@ gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+
+# From https://cloud.google.com/sdk/docs/install#rpm
 [google-cloud-sdk]
 name=Google Cloud SDK
 baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg


### PR DESCRIPTION
At some point in the near future, CentOS 8 will stop being maintained.  Since all of our container-based tooling relies on this, best to get it all working on the new Stream-8 base.

Also included is a really important fix for a bug/problem resulting in CGv2 **NOT** getting disabled in F33 (it was previously) as intended.