### PR TITLE
Reduce image size slightly

### DIFF
--- a/cache_images/fedora_packaging.sh
+++ b/cache_images/fedora_packaging.sh
@@ -187,7 +187,7 @@ DOWNLOAD_PACKAGES=(\
 echo "Installing general build/test dependencies"
 bigto $SUDO dnf install -y $EXARG "${INSTALL_PACKAGES[@]}"
 
-if [[ ${#DOWNLOAD_PACKAGES[@]} -gt 0 ]]; then
+if ((CONTAINER==0)) && [[ ${#DOWNLOAD_PACKAGES[@]} -gt 0 ]]; then
     echo "Downloading packages for optional installation at runtime, as needed."
     # Required for cri-o
     ooe.sh $SUDO dnf -y module enable cri-o:$(get_kubernetes_version)

--- a/cache_images/podman_tooling.sh
+++ b/cache_images/podman_tooling.sh
@@ -5,7 +5,7 @@
 # not be used for any other purpose or from any other context.
 
 echo "Installing runtime tooling"
-export GOPATH
+export GOPATH="${GOPATH:/var/tmp/go}"
 export GOSRC=/var/tmp/go/src/github.com/containers/podman
 export GOCACHE="${GOCACHE:-/root/.cache/go-build}"
 lilto git clone --quiet https://github.com/containers/podman.git "$GOSRC"
@@ -21,6 +21,7 @@ if [[ "$OS_RELEASE_ID" == "ubuntu" ]]; then
     lilto $SUDO make install.libseccomp.sudo
 fi
 
-# Make pristine for other runtime usage/expectations
-$SUDO rm -rf "$GOSRC"
+# Make pristine for other runtime usage/expectations also save a bit
+# of space in the images.
+$SUDO rm -rf "$GOPATH/src" "$GOCACHE"
 $SUDO chown -R root.root /var/tmp/go

--- a/lib.sh
+++ b/lib.sh
@@ -173,6 +173,11 @@ common_finalize() {
 # Called during VM Image setup, not intended for general use.
 rh_finalize() {
     set +e  # Don't fail at the very end
+    if ((CONTAINER)); then  # try to save a little space
+        msg "Cleaning up packaging metadata and cache"
+        $SUDO dnf clean all
+        $SUDO rm -rf /var/cache/dnf
+    fi
     set -x
     # Packaging cache is preserved across builds of container images
     $SUDO rm -f /etc/udev/rules.d/*-persistent-*.rules
@@ -183,6 +188,11 @@ rh_finalize() {
 # Called during VM Image setup, not intended for general use.
 ubuntu_finalize() {
     set +e  # Don't fail at the very end
+    if ((CONTAINER)); then  # try to save a little space
+        msg "Cleaning up packaging metadata and cache"
+        $SUDO apt-get clean
+        $SUDO rm -rf /var/cache/apt
+    fi
     set -x
     # Packaging cache is preserved across builds of container images
     common_finalize


### PR DESCRIPTION
Especially for container images, but also for VMs, it's desirable to
not leave a lot of useless junk around.  This is because the images
are compressed and moved around, both of which benefit from a reduced
quantity of bits.  Attempt to improve the situation by selectively
removing/cleaning cached packages and metadata when/where possible.

Signed-off-by: Chris Evich <cevich@redhat.com>