### PR TITLE
Add fedora-netavark VM image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -194,6 +194,9 @@ cache_images_task:
             PACKER_BUILDS: "prior-fedora"
         - <<: *cache_image
           env:
+            PACKER_BUILDS: "fedora-netavark"
+        - <<: *cache_image
+          env:
             PACKER_BUILDS: "ubuntu"
     env:
       GAC_JSON: ENCRYPTED[7fba7fb26ab568ae39f799ab58a476123206576b0135b3d1019117c6d682391370c801e149f29324ff4b50133012aed9]
@@ -228,6 +231,7 @@ imgts_task:
             ubuntu-b${IMG_SFX}
             fedora-c${IMG_SFX}
             prior-fedora-c${IMG_SFX}
+            fedora-netavark-c${IMG_SFX}
             ubuntu-c${IMG_SFX}
     clone_script: &noop mkdir -p "${CIRRUS_WORKING_DIR}"  # source is not needed
     script: "/usr/local/bin/entrypoint.sh"

--- a/cache_images/fedora-netavark_packaging.sh
+++ b/cache_images/fedora-netavark_packaging.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# This script is called from fedora_setup.sh and various Dockerfiles.
+# It's not intended to be used outside of those contexts.  It assumes the lib.sh
+# library has already been sourced, and that all "ground-up" package-related activity
+# needs to be done, including repository setup and initial update.
+
+set -e
+
+SCRIPT_FILEPATH=$(realpath "${BASH_SOURCE[0]}")
+SCRIPT_DIRPATH=$(dirname "$SCRIPT_FILEPATH")
+REPO_DIRPATH=$(realpath "$SCRIPT_DIRPATH/../")
+
+# shellcheck source=./lib.sh
+source "$REPO_DIRPATH/lib.sh"
+
+msg "Updating/Installing repos and packages for $OS_REL_VER"
+
+bigto ooe.sh $SUDO dnf update -y
+
+INSTALL_PACKAGES=(\
+    bats
+    bridge-utils
+    bzip2
+    cargo
+    clippy
+    curl
+    dbus-daemon
+    findutils
+    firewalld
+    git
+    gzip
+    hostname
+    iproute
+    iptables
+    iputils
+    jq
+    kernel-modules
+    make
+    nftables
+    nmap-ncat
+    openssl
+    openssl-devel
+    policycoreutils
+    redhat-rpm-config
+    rpm-build
+    rsync
+    rust
+    rustfmt
+    sed
+    tar
+    time
+    xz
+    zip
+)
+
+msg "Installing general build/test dependencies"
+bigto $SUDO dnf install -y "${INSTALL_PACKAGES[@]}"
+
+msg "Installing netavark-specific toolchain dependencies"
+export CARGO_HOME="/var/cache/cargo"  # must match .cirrus.yml in netavark repo
+$SUDO env CARGO_HOME=$CARGO_HOME cargo install mandown sccache
+
+# It was observed in F33, dnf install doesn't always get you the latest/greatest
+lilto $SUDO dnf update -y

--- a/cache_images/gce.yml
+++ b/cache_images/gce.yml
@@ -50,6 +50,11 @@ builders:
       name: 'prior-fedora'
       source_image_family: 'prior-fedora-base'
 
+    - <<: *gce_hosted_image
+      name: 'fedora-netavark'
+      source_image: 'fedora-b{{user `IMG_SFX`}}'
+      source_image_family: 'fedora-base'
+
 provisioners:
     - type: 'shell'
       inline:
@@ -60,7 +65,7 @@ provisioners:
       source: '{{ pwd }}/'
       destination: "/tmp/automation_images"
 
-    - only: ['fedora', 'prior-fedora']
+    - only: ['fedora', 'prior-fedora', 'fedora-netavark']
       type: 'shell'
       inline:
         - 'set -e'


### PR DESCRIPTION
The CI needs of the netavark project are significantly different
from the other golang-based projects.  Add a dedicated VM image
for the project, based on the latest Fedora base image.

Signed-off-by: Chris Evich <cevich@redhat.com>