### PR TITLE
Github workflow: Fix error-notice e-mail content.

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -99,4 +99,4 @@ jobs:
                 subject: Github workflow error on ${{github.repository}}
                 to: ${{env.RCPTCSV}}
                 from: ${{secrets.ACTION_MAIL_SENDER}}
-                body: "Job failed: https://github.com/${{github.repository}}/runs/${{github.job}}?check_suite_focus=true"
+                body: "Job failed: https://github.com/${{github.repository}}/runs/${{github.run_id}}?check_suite_focus=true"


### PR DESCRIPTION
The documentation is less than clear on which magic token gives you the
run number component of the URL.  I think `run_id` is the correct one.

Signed-off-by: Chris Evich <cevich@redhat.com>