### PR TITLE
[CI:DOCS] Add get_ci_vm warning about ssh key passphrases

### DIFF
--- a/get_ci_vm/entrypoint.sh
+++ b/get_ci_vm/entrypoint.sh
@@ -357,9 +357,14 @@ init_gcevm() {
     _dbg_envars INST_NAME GCLOUD SSH_CMD SCP_CMD CREATE_CMD CLEANUP_CMD
 
     if ! has_valid_credentials; then
-        warn "Can't find valid GCP credentials, attempting to (re)initialize.
-If asked, please choose \"#1: Re-initialize\", \"login\", and \"$GCLOUD_ZONE\" GCLOUD_ZONE,
-otherwise simply follow the prompts"
+        warn "\
+Can't find valid GCP credentials, attempting to (re)initialize.
+If asked, please choose '#1: Re-initialize', 'login', and a nearby
+GCLOUD_ZONE, otherwise simply follow the prompts.
+
+Note: If asked to set a SSH-key passphrase, DO NOT SET ONE, it
+      will make your life miserable! Set an empty password for the key.
+"
         $GCLOUD init --project=$GCLOUD_PROJECT --console-only --skip-diagnostics
         if ! has_valid_credentials; then
             die "Unable to obtain GCP access credentials, please seek assistance."


### PR DESCRIPTION
When initializing, gcloud will check for a special ssh key under
~/.config/gcloud/ssh.  When absent, it will generate a new one and
prompt the user for a passphrase.  If a passphrase is set, it will be
requested again for every single gcloud operation, with no possibility
to add it to a desktop keychain.  To help prevent this aggravation,
include it in a warning message at initialization time.

Signed-off-by: Chris Evich <cevich@redhat.com>