### PR TITLE
Fix build-push version-tagging

### DIFF
--- a/build-push/bin/tag_version.sh
+++ b/build-push/bin/tag_version.sh
@@ -36,8 +36,8 @@ if [[ "$CTX_NAME" == "stable" ]]; then
     # shellcheck disable=SC2154
     msg "Found image command version '$img_cmd_version'"
     # shellcheck disable=SC2154
-    $RUNTIME tag $FQIN:latest $FQIN:$img_cmd_version
-    msg "Successfully tagged $FQIN:$img_cmd_version"
+    $RUNTIME tag $FQIN:latest $FQIN:v${img_cmd_version#v}
+    msg "Successfully tagged $FQIN:v${img_cmd_version#v}"
 else
     warn "Not tagging '$CTX_NAME' context of '$FQIN'"
 fi

--- a/build-push/test.sh
+++ b/build-push/test.sh
@@ -41,7 +41,7 @@ git config --local commit.gpgsign "false"
 # is tested here, since it involves the most complex workflow.
 mkdir -vp "contrib/testimage/stable"
 cd "contrib/testimage/stable"
-echo "build-push-test version $FAKE_VERSION" | tee "FAKE_VERSION"
+echo "build-push-test version v$FAKE_VERSION" | tee "FAKE_VERSION"
 cat <<EOF | tee "Containerfile"
 FROM registry.fedoraproject.org/fedora:latest
 ADD /FAKE_VERSION /
@@ -70,10 +70,10 @@ for _fqin in $TEST_FQIN $TEST_FQIN2; do
         # looking up the image in local storage.  This bug is fixed in later
         # versions.  For now, query the manifest directly for the image sha256.
         _q='.manifests[] | select(.platform.architecture == "'"$_arch"'") | .digest'
-        _s=$(podman manifest inspect $_fqin:$FAKE_VERSION | jq -r "$_q")
-        msg "Found '$_arch' in manifest-list $_fqin:$FAKE_VERSION as digest $_s"
+        _s=$(podman manifest inspect $_fqin:v$FAKE_VERSION | jq -r "$_q")
+        msg "Found '$_arch' in manifest-list $_fqin:v$FAKE_VERSION as digest $_s"
         if [[ -z "$_s" ]]; then
-            die "Failed to get sha256 for FQIN '$_fqin:$FAKE_VERSION' ($_arch)"
+            die "Failed to get sha256 for FQIN '$_fqin:v$FAKE_VERSION' ($_arch)"
         fi
         msg "Testing container can ping localhost"
         showrun podman run -i --rm "$_fqin@$_s" ping -q -c 1 127.0.0.1

--- a/cache_images/fedora-netavark_packaging.sh
+++ b/cache_images/fedora-netavark_packaging.sh
@@ -19,16 +19,11 @@ msg "Updating/Installing repos and packages for $OS_REL_VER"
 bigto ooe.sh $SUDO dnf update -y
 
 INSTALL_PACKAGES=(\
-	btrfs-progs-devel
-	golang
-	gpgme-devel
-	libassuan-devel
-	libseccomp-devel
-	systemd-devel
     automake
     bats
     bind-utils
     bridge-utils
+    btrfs-progs-devel
     bzip2
     curl
     dbus-daemon
@@ -37,6 +32,8 @@ INSTALL_PACKAGES=(\
     gcc
     gcc-c++
     git
+    golang
+    gpgme-devel
     gzip
     hostname
     iproute
@@ -45,6 +42,8 @@ INSTALL_PACKAGES=(\
     jq
     kernel-devel
     kernel-modules
+    libassuan-devel
+    libseccomp-devel
     make
     nftables
     nmap-ncat
@@ -55,6 +54,7 @@ INSTALL_PACKAGES=(\
     rsync
     sed
     slirp4netns
+    systemd-devel
     tar
     time
     xz


### PR DESCRIPTION
The prior github-actions implementation prefixed version-tags with a 'v'
character.  Since this letter could (for some contexts) be part of the
version-number read in from the application, ensure the mod-script
strips it out before adding it's own 'v' prefix.