### PR TITLE
Add installation script for build-push main.sh

### DIFF
--- a/build-push/.install.sh
+++ b/build-push/.install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script is intended to be used from two places only:
+# 1) When building the build-push VM image, to install the scripts as-is
+#    in a PR in order for CI testing to operate on them.
+# 2) From the autoupdate.sh script, when $BUILDPUSHAUTOUPDATED is unset
+#    or '0'.  This clones the latest repository to install (possibly)
+#    updated scripts.
+#
+# WARNING: Use under any other circumstances will probably screw things up.
+
+if [[ -z "$BUILDPUSHAUTOUPDATED" ]];
+then
+    echo "This script must only be run under Packer or autoupdate.sh"
+    exit 1
+fi
+
+source /etc/automation_environment
+
+#shellcheck disable=SC2154
+cd $(dirname "$SCRIPT_FILEPATH") || exit 1
+# Must be installed into $AUTOMATION_LIB_PATH/../bin which is on $PATH
+cp ./bin/* $AUTOMATION_LIB_PATH/../bin/
+cp ./lib/* $AUTOMATION_LIB_PATH/
+chmod +x $AUTOMATION_LIB_PATH/../bin/*

--- a/cache_images/build-push_packaging.sh
+++ b/cache_images/build-push_packaging.sh
@@ -40,6 +40,7 @@ lilto $SUDO dnf update -y
 install_automation_tooling build-push
 
 # Install main scripts into directory on $PATH
+cd $REPO_DIRPATH/build-push
 set -x
-$SUDO cp $REPO_DIRPATH/build-push/bin/* $AUTOMATION_LIB_PATH/../bin/
-$SUDO chmod +x $AUTOMATION_LIB_PATH/../bin/*
+# Do not auto-update to allow testing inside a PR
+$SUDO env BUILDPUSHAUTOUPDATED=1 bash ./.install.sh


### PR DESCRIPTION
***This is part one, part two is in https://github.com/containers/netavark/pull/272***

A future commit will add an auto-update feature to main.sh.  This
requires an installation script which can be shared with both VM image
composition and auto-updating.  The installation script must exist first
on the main branch, before the auto-update feature can be committed.