### PR TITLE
Build-push: Also tag vX.Y and vX stable images

### DIFF
--- a/build-push/bin/tag_version.sh
+++ b/build-push/bin/tag_version.sh
@@ -33,11 +33,26 @@ if [[ "$CTX_NAME" == "stable" ]]; then
     # retrieving it from the image content is beyond the scope
     # of this script.
     req_env_vars img_cmd_version
+    img_cmd_version=v${img_cmd_version#v}
+    if egrep -q '^v[0-9]+\.[0-9]+\.[0-9]+'<<<"$img_cmd_version"; then
+        msg "Found image command version '$img_cmd_version'"
+    else
+        die "Encountered unexpected/non-conforming version '$img_cmd_version'"
+    fi
+
     # shellcheck disable=SC2154
-    msg "Found image command version '$img_cmd_version'"
-    # shellcheck disable=SC2154
-    $RUNTIME tag $FQIN:latest $FQIN:v${img_cmd_version#v}
-    msg "Successfully tagged $FQIN:v${img_cmd_version#v}"
+    $RUNTIME tag $FQIN:latest $FQIN:$img_cmd_version
+    msg "Successfully tagged $FQIN:$img_cmd_version"
+
+    # Tag as x.y to provide a consistent tag even for a future z+1
+    xy_ver=$(awk -F '.' '{print $1"."$2}'<<<"$img_cmd_version")
+    $RUNTIME tag $FQIN:latest $FQIN:$xy_ver
+    msg "Successfully tagged $FQIN:$xy_ver"
+
+    # Tag as x to provide consistent tag even for a future y+1
+    x_ver=$(awk -F '.' '{print $1}'<<<"$xy_ver")
+    $RUNTIME tag $FQIN:latest $FQIN:$x_ver
+    msg "Successfully tagged $FQIN:$x_ver"
 else
     warn "Not tagging '$CTX_NAME' context of '$FQIN'"
 fi

--- a/build-push/test.sh
+++ b/build-push/test.sh
@@ -17,7 +17,10 @@ TESTARCHES="amd64 arm64"
 ARCHES=$(tr " " ","<<<"$TESTARCHES")
 export ARCHES
 # Contrived "version" for testing purposes
-FAKE_VERSION=$RANDOM
+FAKE_VER_X=$RANDOM
+FAKE_VER_Y=$RANDOM
+FAKE_VER_Z=$RANDOM
+FAKE_VERSION="$FAKE_VER_X.$FAKE_VER_Y.$FAKE_VER_Z"
 # Contrived source repository for testing
 SRC_TMP=$(mktemp -p '' -d tmp-build-push-test-XXXX)
 # Do not change, main.sh is sensitive to the 'testing' name
@@ -82,6 +85,18 @@ for _fqin in $TEST_FQIN $TEST_FQIN2; do
         fi
         msg "Testing container can ping localhost"
         showrun podman run -i --rm "$_fqin@$_s" ping -q -c 1 127.0.0.1
+
+        xy_ver="v$FAKE_VER_X.$FAKE_VER_Y"
+        msg "Testing tag '$xy_ver'"
+        if ! podman manifest inspect $_fqin:$xy_ver &> /dev/null; then
+            die "Failed to find manifest-list tagged '$xy_ver'"
+        fi
+
+        x_ver="v$FAKE_VER_X"
+        msg "Testing tag '$x_ver'"
+        if ! podman manifest inspect $_fqin:$x_ver &> /dev/null; then
+            die "Failed to find manifest-list tagged '$x_ver'"
+        fi
 
         #TODO: Test org.opencontainers.image.source value
         #TODO: fails, returns null for some reason


### PR DESCRIPTION
Since these images build daily, and the full (X.Y.Z) version could
change at any time, it may be difficult for downstream users to track a
uniform FQIN while also receiving security updates.  Since all tags of
produced manifest-lists are already pushed, simply update the
tag_version.sh mod-script to produce the additional tagged
manifest-lists.  Verify this has happened by enhancing the CI test to
check for the new tags.

Signed-off-by: Chris Evich <cevich@redhat.com>