### PR TITLE
[CI:TOOLING] Fix runtime check of non-exported variable

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -324,7 +324,7 @@ test_build-push_task:
         - cache_images
     gce_instance:
         image_project: "libpod-218412"
-        image_name: "build-push-c${IMG_SFX}"
+        image_family: 'build-push-cache'
         zone: "us-central1-a"
         disk: 200
         # More muscle to emulate multi-arch

--- a/build-push/lib/autoupdate.sh
+++ b/build-push/lib/autoupdate.sh
@@ -6,7 +6,8 @@
 # main.sh.  This allows the scripts to be updated without requiring new VM
 # images to be composed and deployed.
 
-BUILDPUSHAUTOUPDATED="${BUILDPUSHAUTOUPDATED:-0}"
+# Must be exported - .install.sh checks this is set.
+export BUILDPUSHAUTOUPDATED="${BUILDPUSHAUTOUPDATED:-0}"
 
 if ! ((BUILDPUSHAUTOUPDATED)); then
     msg "Auto-updating build-push operational scripts..."


### PR DESCRIPTION
Related to https://github.com/containers/automation_images/pull/123 the
installer checks that it's running under an expected environment.  This
is always the case under test, but not under normal runtime conditions.
Fix this by making sure the check-variable is available to the installer
when auto-updating.

Also, update CI config so test-build-push task uses the latest
build-push image by family-name instead of the image tied to the PR.
This allows testing to occur under both normal and (magic)
`[CI:TOOLING]` PRs.