### PR TITLE
Fix re-exec outside of starting dir.

### DIFF
--- a/build-push/lib/autoupdate.sh
+++ b/build-push/lib/autoupdate.sh
@@ -5,6 +5,9 @@
 # it will download the latest version of the build-push scripts and re-exec
 # main.sh.  This allows the scripts to be updated without requiring new VM
 # images to be composed and deployed.
+#
+# WARNING: Changes to this script _do_ require new VM images as auto-updating
+# the auto-update script would be complex and hard to test.
 
 # Must be exported - .install.sh checks this is set.
 export BUILDPUSHAUTOUPDATED="${BUILDPUSHAUTOUPDATED:-0}"
@@ -22,7 +25,8 @@ if ! ((BUILDPUSHAUTOUPDATED)); then
     msg "Installing..."
     cd $GITTMP/build-push || exit 1
     bash ./.install.sh
-    cd /
+    # Important: Return to directory main.sh was started from
+    cd - || exit 1
     rm -rf "$GITTMP"
 
     #shellcheck disable=SC2145


### PR DESCRIPTION
When auto-updating, ensure the new version is re-exec'd from the same
starting directory is was originally called from.  This is required
because the context-directory argument is a relative path (by design).
Also add a reminder that touching the autoupdate.sh script itself, does
require building/deploying new VM images.