### PR TITLE
[CI:DOCS] Minor: Update NM workaround for netavark

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -138,7 +138,7 @@ nm_ignore_cni() {
     $SUDO mkdir -p /etc/NetworkManager/conf.d/
     cat << EOF | $SUDO tee /etc/NetworkManager/conf.d/podman-cni.conf
 [keyfile]
-unmanaged-devices=interface-name:cni-podman*;interface-name:veth*
+unmanaged-devices=interface-name:*podman*;interface-name:veth*
 EOF
 }
 


### PR DESCRIPTION
While the `veth*` is probably the effective statement for preventing
CI test flakes, also ignore any bridges/interfaces with `podman` in
the name.

Signed-off-by: Chris Evich <cevich@redhat.com>