### PR TITLE
Download/cache 'podman-plugins' package in Fedora

### DIFF
--- a/cache_images/fedora_packaging.sh
+++ b/cache_images/fedora_packaging.sh
@@ -179,6 +179,7 @@ DOWNLOAD_PACKAGES=(\
     oci-umount
     parallel
     podman-docker
+    podman-plugins
     python3-pytest
     python3-virtualenv
 )


### PR DESCRIPTION
Specifically, the 'dnsname' CNI plugin is needed by CI testing in
containers/common.  Download it into the VM for installation at runtime.

Signed-off-by: Chris Evich <cevich@redhat.com>