### PR TITLE
Update the registry used for Skopeo CI to 2.8.1

### DIFF
--- a/skopeo_cidev/Containerfile
+++ b/skopeo_cidev/Containerfile
@@ -12,7 +12,7 @@ RUN dnf -y update && \
     dnf clean all
 
 ENV REG_REPO="https://github.com/docker/distribution.git" \
-    REG_COMMIT="47a064d4195a9b56133891bbb13620c3ac83a827" \
+    REG_COMMIT="b5ca020cfbe998e5af3457fda087444cf5116496" \
     REG_COMMIT_SCHEMA1="ec87e9b6971d831f0eff752ddb54fb64693e51cd" \
     OSO_REPO="https://github.com/openshift/origin.git" \
     OSO_TAG="v1.5.0-alpha.3"


### PR DESCRIPTION
... primarily so that it accepts OCI-formatted images.

Proof of concept, as well as other updates necessary to work with that registry version, are in https://github.com/containers/image/pull/1574 .

See https://github.com/containers/skopeo/issues/1673 for more context.