### PR TITLE
Use packaged bats in Fedora, side-load for Ubuntu

### DIFF
--- a/cache_images/fedora_packaging.sh
+++ b/cache_images/fedora_packaging.sh
@@ -41,6 +41,7 @@ INSTALL_PACKAGES=(\
     autoconf
     automake
     bash-completion
+    bats
     bridge-utils
     btrfs-progs-devel
     buildah

--- a/cache_images/podman_tooling.sh
+++ b/cache_images/podman_tooling.sh
@@ -21,7 +21,7 @@ if [[ "$OS_RELEASE_ID" == "ubuntu" ]]; then
     bats_version="1.7.0"
     dl_url="https://github.com/bats-core/bats-core/archive/v${bats_version}.tar.gz"
     echo "Installing bats $bats_version"
-    curl --fail --location "$dl_url" | tar xzv -C /tmp
+    curl --fail --location "$dl_url" | tar xz -C /tmp
     pushd /tmp/bats-core-$bats_version
     $SUDO ./install.sh /usr/local  # prints install location
     popd

--- a/cache_images/ubuntu_packaging.sh
+++ b/cache_images/ubuntu_packaging.sh
@@ -143,7 +143,7 @@ INSTALL_PACKAGES=(\
 # Necessary to update cache of newly added repos
 lilto $SUDO apt-get -q -y update
 
-if (($OS_RELEASE_VER>=2104)); then
+if (($OS_RELEASE_VER==2104)); then
     echo "Blocking golang-* package interfearance with kubik containers-common"
     $SUDO apt-mark hold golang-github-containers-common golang-github-containers-image
 fi

--- a/cache_images/ubuntu_packaging.sh
+++ b/cache_images/ubuntu_packaging.sh
@@ -21,7 +21,6 @@ bigto ooe.sh $SUDO apt-get -qq -y upgrade
 
 echo "Configuring additional package repositories"
 
-
 # Useful version of criu is only available from launchpad repo
 if [[ "$OS_RELEASE_VER" -le 2004 ]]; then
     lilto ooe.sh $SUDO add-apt-repository --yes ppa:criu/ppa
@@ -44,9 +43,8 @@ curl --fail --silent --location --url "$GPG_URL" | \
     $SUDO tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable_ci.gpg &> /dev/null
 
 
-# Removed golang-1.14 from install packages due to known
-# performance reason.  Reinstall when ubuntu has 1.16.
-
+# N/B: DO NOT install the bats package on Ubuntu VMs, it's broken.
+# ref: (still open) https://bugs.launchpad.net/ubuntu/+source/bats/+bug/1882542
 INSTALL_PACKAGES=(\
     apache2-utils
     apparmor


### PR DESCRIPTION
Fixes https://github.com/containers/automation_images/issues/139

N/B: Using these images requires an update to the podman repo. to remove
the bats installer script and `Makefile` target.