### PR TITLE
[CI:TOOLING] Fix failure to upload package cache

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,6 +12,7 @@ env:
     PACKER_VERSION: &PACKER_VERSION "1.8.0"
     # Unique suffix label to use for all images produced by _this_ run (build)
     IMG_SFX: "${CIRRUS_BUILD_ID}"
+    TEMPDIR: "/tmp/automation_images_tmp"  # needed by Makefile & caching
 
 gcp_credentials: ENCRYPTED[823fdbc2fee3c27fa054ba1e9cfca084829b5e71572f1703a28e0746b1a924ee5860193f931adce197d40bf89e7027fe]
 
@@ -102,8 +103,9 @@ container_images_task: &container_images
         REG_PASSWORD: ENCRYPTED[52268944bb0d6642c33efb1c5d7fb82d0c40f9e6988448de35827f9be2cc547c1383db13e8b21516dbd7a0a69a7ae536]
     script: ci/make_container_images.sh;
     package_cache: &package_cache
-        folder: "/tmp/automation_images_tmp/.cache/**"
-        fingerprint_key: "${TARGET_NAME}-cache-version-1"
+        folder: "$TEMPDIR/.cache/**/*"
+        fingerprint_key: "${TARGET_NAME}-cache-version-2"
+        reupload_on_changes: true
 
 
 tooling_images_task:
@@ -127,8 +129,8 @@ tooling_images_task:
             ci/make_container_images.sh;
         done
     package_cache:
-        folder: "/tmp/automation_images_tmp/.cache/**"
-        fingerprint_key: "tooling-cache-version-1"
+        <<: *package_cache
+        fingerprint_key: "tooling-cache-version-2"
 
 
 base_images_task:

--- a/ci/make_container_images.sh
+++ b/ci/make_container_images.sh
@@ -26,6 +26,7 @@ req_vars=(\
     DEST_FQIN
     REG_USERNAME
     REG_PASSWORD
+    TEMPDIR
 )
 for req_var in "${req_vars[@]}"; do
     if [[ -z "${!req_var}" ]]; then
@@ -39,6 +40,12 @@ done
 SRC_FQIN="$TARGET_NAME:$IMG_SFX"
 
 make "$TARGET_NAME" IMG_SFX=$IMG_SFX
+
+# Cirrus-CI will try to collect up the package cache, but fails
+# on special files (like gpg agent sockets).  Remove them.
+echo "Clearing special files from package cache"
+# shellcheck disable=SC2154
+find $TEMPDIR/.cache -type s -exec rm -vf '{}' +
 
 # Prevent pushing 'latest' images from PRs, only branches and tags
 # shellcheck disable=SC2154

--- a/imgts/Containerfile
+++ b/imgts/Containerfile
@@ -2,9 +2,10 @@ FROM quay.io/centos/centos:stream8
 
 # Only needed for installing build-time dependencies
 COPY /imgts/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
-RUN dnf -y --setopt=keepcache=true update && \
-    dnf -y --setopt=keepcache=true install epel-release python3 && \
-    dnf -y --setopt=keepcache=true --exclude=google-cloud-sdk-366.0.0-1 \
+RUN echo 'keepcache=true' >> /etc/dnf/dnf.conf && \
+    dnf -y update && \
+    dnf -y install epel-release python3 && \
+    dnf -y --exclude=google-cloud-sdk-366.0.0-1 \
         install google-cloud-sdk
 
 # These all represent required variables which must be set by caller

--- a/podman/setup.sh
+++ b/podman/setup.sh
@@ -13,9 +13,14 @@ REPO_DIRPATH=$(realpath "$SCRIPT_DIRPATH/../")
 source "$REPO_DIRPATH/lib.sh"
 
 if   [[ "$OS_RELEASE_ID" == "ubuntu" ]]; then
+    cat > /etc/apt/apt.conf.d/01keep-debs << EOF
+Binary::apt::APT::Keep-Downloaded-Packages "true";
+APT::Keep-Downloaded-Packages "false";
+EOF
     bash base_images/ubuntu_base-setup.sh
     bash cache_images/ubuntu_setup.sh
 elif [[ "$OS_RELEASE_ID" == "fedora" ]]; then
+    echo 'keepcache=true' >> /etc/dnf/dnf.conf
     bash base_images/fedora_base-setup.sh
     bash cache_images/fedora_setup.sh
 else

--- a/skopeo_cidev/Containerfile
+++ b/skopeo_cidev/Containerfile
@@ -6,10 +6,10 @@ FROM ${BASE_NAME}:${BASE_TAG}
 ENV LC_ALL="C"
 
 COPY /packages.txt /root/
-RUN dnf -y update && \
+RUN echo 'keepcache=true' >> /etc/dnf/dnf.conf && \
+    dnf -y update && \
     dnf -y install $(sed -r -e '/^#/d' -e '/^$/d' /root/packages.txt) && \
-    dnf -y upgrade && \
-    dnf clean all
+    dnf -y upgrade
 
 ENV REG_REPO="https://github.com/docker/distribution.git" \
     REG_COMMIT="b5ca020cfbe998e5af3457fda087444cf5116496" \


### PR DESCRIPTION
Fix directory name and required upload argument problem in
`.cirrus.yml`.  Also fix container images such that they actually retain
their `dnf` or `apt` cache (volume-mounted from host).  This should
provide a minor build speedup over time.

Signed-off-by: Chris Evich <cevich@redhat.com>