### PR TITLE
Skip specified image builds based on PR labels

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -247,6 +247,8 @@ imgts_task:
         cpu: 2
         memory: '2G'
     env:
+        # Not all $IMGNAMES may have been built, don't fail if some are missing
+        REQUIRE_ALL: 0  # This should ONLY be set `0` on this repository!
         BUILDID: "$CIRRUS_BUILD_ID"
         REPOREF: "$CIRRUS_REPO_NAME"
         GCPJSON: ENCRYPTED[112c55192dba9a7edd1889a7e704aa1e6ae40730b97ad8ebcbae2bb5f4ff84c7e9ca5b955baaf1f69e7b9e5c5a14a4d3]

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,6 +56,7 @@ image_builder_task:
         docker_arguments:
             PACKER_VERSION: *PACKER_VERSION
     env:
+      PACKER_BUILDS: 'image-builder'
       # Google Application Credentials (JSON) with access to create VM images
       GAC_JSON: ENCRYPTED[7fba7fb26ab568ae39f799ab58a476123206576b0135b3d1019117c6d682391370c801e149f29324ff4b50133012aed9]
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ magic strings in their *title* text:
 * `[CI:TOOLING]` - Only perform validation steps, then [build and test
   the tooling container images](README.md#tooling) only.
 
+Additionally, you may use one/more [PR labels to disable certain
+builds](README.md#bypassing-certain-builds).
+
 
 # Building VM Images
 
@@ -83,6 +86,27 @@ please [see it's documentation page](https://www.packer.io/docs).
    installing build & test dependencies, but also includes some
    kernel and systemd services configuration.
 
+## Bypassing certain builds
+
+With a large number of VM and Container images to build, it's inevitable
+that a flake will occur on an image the author does not care about.  For
+example, if you're building images *only* to update Buildah CI, you don't
+care to produce the `fedora-netavark` VM image nor the `skopeo_cidev`
+container image.
+
+Should a flake occur on an build that's inconsequential to a specific
+CI environment, there is a mechanism to bypass certain builds.
+
+**Note**: This will *not* bypass container tooling images (they're always
+required). Nor will it properly handle any build dependencies.
+For example skipping a `fedora` build will cause a failure in
+`build-push`(since it depends on the `fedora` base image).
+
+To bypass a specific build, find a `no_<name>` GitHub label matching
+the build name.  Add that label to the PR and re-push or re-run a
+previously failed build. It will then skip + automatically succeed.
+Similarly, if you make a mistake with the labels, you can remove or
+change them and re-run any affected tasks.
 
 ## The last part first (overview step 4)
 

--- a/ci/make_base_images.sh
+++ b/ci/make_base_images.sh
@@ -19,6 +19,10 @@ elif [[ -z "$IMG_SFX" ]] || [[ -z "$PACKER_BUILDS" ]]; then
     die "Required non-empty values for \$IMG_SFX=$IMG_SFX and \$PACKER_BUILDS=$PACKER_BUILDS"
 fi
 
+if skip_on_pr_label; then
+    exit 0  # skip build
+fi
+
 set_gac_filepath
 set_aws_filepath
 

--- a/ci/make_cache_images.sh
+++ b/ci/make_cache_images.sh
@@ -20,6 +20,10 @@ elif [[ -z "$IMG_SFX" ]] || [[ -z "$PACKER_BUILDS" ]]; then
     die "Required non-empty values for \$IMG_SFX=$IMG_SFX and \$PACKER_BUILDS=$PACKER_BUILDS"
 fi
 
+if skip_on_pr_label; then
+    exit 0  # skip build
+fi
+
 set_gac_filepath
 set_aws_filepath
 

--- a/ci/make_container_images.sh
+++ b/ci/make_container_images.sh
@@ -19,6 +19,10 @@ if [[ "$CI" != "true" ]] || [[ "$CIRRUS_CI" != "$CI" ]]; then
     die "Unexpected \$CI='$CI' and/or \$CIRRUS_CI='$CIRRUS_CI'"
 fi
 
+if skip_on_pr_label; then
+    exit 0  # skip build
+fi
+
 declare -a req_vars
 req_vars=(\
     IMG_SFX

--- a/ci/make_image_builder.sh
+++ b/ci/make_image_builder.sh
@@ -18,6 +18,10 @@ elif [[ -z "$IMG_SFX" ]]; then
     die "Required non-empty values for \$IMG_SFX=$IMG_SFX"
 fi
 
+if skip_on_pr_label; then
+    exit 0  # skip build
+fi
+
 set_gac_filepath
 
 set -exo pipefail

--- a/imgts/entrypoint.sh
+++ b/imgts/entrypoint.sh
@@ -28,6 +28,9 @@ ARGS="
 [[ -n "$IMGNAMES" ]] || \
     die 1 "No \$IMGNAMES were specified."
 
+# Under some runtime conditions, not all images may be available
+REQUIRE_ALL=${REQUIRE_ALL:-1}
+
 # Don't allow one bad apple to ruin the whole batch
 ERRIMGS=''
 
@@ -53,5 +56,8 @@ do
     fi
 done
 
-[[ -z "$ERRIMGS" ]] || \
-    die 2 "ERROR: Failed to update one or more image timestamps: $ERRIMGS"
+if [[ -n "$ERRIMGS" ]]; then
+    die_or_warn=die
+    ((REQUIRE_ALL)) || die_or_warn=warn
+    $die_or_warn 2 "Failed to update one or more image timestamps: $ERRIMGS"
+fi

--- a/imgts/lib_entrypoint.sh
+++ b/imgts/lib_entrypoint.sh
@@ -18,6 +18,15 @@ die() {
     exit "$EXIT"
 }
 
+# Similar to die() but it ignores the first parameter (exit code)
+# to allow direct use in place of an (otherwise) die() call.
+warn() {
+    IGNORE=$1
+    shift
+    MSG="$*"
+    echo -e "${RED}WARNING: $MSG${NOR}"
+}
+
 # Hilight messages not coming from a shell command
 msg() {
     echo -e "${YEL}${1:-NoMessageGiven}${NOR}"


### PR DESCRIPTION
With an ever growing number of images to build, it's inevitable that
a flake will occur on an image the author does not care about.  Should
this occur, provide a runtime-method by which a 'no_<name>' label can be
added to the PR before re-running the failure.  The specified `<name>`
build will then be bypassed.

Note: This will not bypass container tooling images (they're always
required). Nor will it properly handle any build dependencies.
For example a `no_fedora` label will cause a build failure of the
`build-push` image, since it depends on the `fedora` base image.