### PR TITLE
Force CgroupsV1 on Ubuntu

### DIFF
--- a/cache_images/ubuntu_setup.sh
+++ b/cache_images/ubuntu_setup.sh
@@ -23,7 +23,8 @@ bash $SCRIPT_DIRPATH/ubuntu_packaging.sh
 
 if ! ((CONTAINER)); then
     warn "Making Ubuntu kernel to enable cgroup swap accounting"
-    SEDCMD='s/^GRUB_CMDLINE_LINUX="(.*)"/GRUB_CMDLINE_LINUX="\1 cgroup_enable=memory swapaccount=1"/'
+    warn "Forcing CgroupsV1"
+    SEDCMD='s/^GRUB_CMDLINE_LINUX="(.*)"/GRUB_CMDLINE_LINUX="\1 cgroup_enable=memory swapaccount=1 systemd.unified_cgroup_hierarchy=0"/'
     ooe.sh $SUDO sed -re "$SEDCMD" -i /etc/default/grub.d/*
     ooe.sh $SUDO sed -re "$SEDCMD" -i /etc/default/grub
     ooe.sh $SUDO update-grub


### PR DESCRIPTION
PR #115 removed a force-cgroups-v2 setup for Ubuntu, possibly
assuming that Ubuntu uses cgroups v1 by default? That doesn't
seem to be the case: the Ubuntu I've looked at (via Cirrus
rerun-with-terminal) seems to default to v2. End result is
that we've been running CI for months without testing runc.
This PR forces cgroups v1 on Ubuntu, via grub boot args.
 
As of 2022-07-20 the version of criu in Ubuntu is broken,
which requires us to install from something called OBS.
There was some OBS-installing code present, but it didn't
lend itself to reuse, so I refactored it and added a
temporary use-criu-from-obs line with a timestamped FIXME.

Signed-off-by: Ed Santiago <santiago@redhat.com>
