### PR TITLE
[CI:TOOLING] Upgrade automation library

### DIFF
--- a/get_ci_vm/good_repo_test/.cirrus.yml
+++ b/get_ci_vm/good_repo_test/.cirrus.yml
@@ -1,5 +1,9 @@
 ---
 
+aws_test_task:
+    ec2_instance:
+        image: ami-1234567890
+
 google_test_task:
     gce_instance:
         image_name: test-image-name

--- a/get_ci_vm/test.sh
+++ b/get_ci_vm/test.sh
@@ -169,6 +169,10 @@ good_init() {
     CIRRUS_TASK="--list"
     init
 }
+testf "Verify get_inst_image() returns expected aws task name" \
+    good_init 0 "aws_test" \
+    get_inst_image
+
 testf "Verify get_inst_image() returns expected google task name" \
     good_init 0 "google_test" \
     get_inst_image

--- a/lib.sh
+++ b/lib.sh
@@ -19,7 +19,7 @@ OS_REL_VER="$OS_RELEASE_ID-$OS_RELEASE_VER"
 # This location is checked by automation in other repos, please do not change.
 PACKAGE_DOWNLOAD_DIR=/var/cache/download
 
-INSTALL_AUTOMATION_VERSION="4.0.0"
+INSTALL_AUTOMATION_VERSION="4.1.1"
 
 PUSH_LATEST="${PUSH_LATEST:-0}"
 


### PR DESCRIPTION
Specifically, v4.1.1 includes a fix for `get_ci_vm` so it doesn't barf
when encountering `ec2_instance`.  Tested by manually building the
container image and running it using podman's `hack/get_ci_vm.sh`
script.  Found the `--list` operation behaves correctly.  Found the
correct/expected error message is returned when requesting a VM for an
`ec2_instance` task.