### PR TITLE
Fix dnf update installing netavark/aardvark-dns

### DIFF
--- a/get_ci_vm/test.sh
+++ b/get_ci_vm/test.sh
@@ -231,6 +231,8 @@ mock_gcevm_workflow() {
 }
 # Don't confuse the actual repo. by nesting another repo inside
 tar -xzf "$GOOD_TEST_REPO/dot_git.tar.gz" -C "$GOOD_TEST_REPO" .git
+# Ignore ownership security checks
+git config --system --add safe.directory $GOOD_TEST_REPO
 # Setup should tarball new files in the repo.
 echo "testing" > "$GOOD_TEST_REPO/uncommited_file"
 # Setup should tarball changed files in the repo.

--- a/lib.sh
+++ b/lib.sh
@@ -217,6 +217,26 @@ get_pr_labels() {
     echo -n "$labels"
 }
 
+remove_netavark_aardvark_files() {
+    req_env_vars OS_RELEASE_ID
+    # OS_RELEASE_ID is defined by automation-library
+    # shellcheck disable=SC2154
+    if [[ "$OS_RELEASE_ID" =~ "ubuntu" ]]
+    then
+        die "Ubuntu netavark/aardvark-dns testing is not supported"
+    fi
+
+        LISTING_CMD="rpm -ql podman"
+
+    # yum/dnf/dpkg may list system directories, only remove files
+    rpm -ql netavark aardvark-dns | while read fullpath
+    do
+        # Sub-directories may contain unrelated/valuable stuff
+        if [[ -d "$fullpath" ]]; then continue; fi
+        sudo rm -vf "$fullpath"
+    done
+}
+
 # Warning: DO NOT USE the following functions willy-nilly!
 # They are only intended to be called by other setup scripts, as the very
 # last step during the build process.  They're purpose is to "reset" the


### PR DESCRIPTION
These packages should _never_ be pre-installed in the CI images for
testing in the netavark & aardvark-dns repositories.  Ensure they aren't
brought in by a package update in addition to the install.

Signed-off-by: Chris Evich <cevich@redhat.com>