### PR TITLE
[CI:DOCS] Support only golang 1.18

### DIFF
--- a/cache_images/ubuntu_packaging.sh
+++ b/cache_images/ubuntu_packaging.sh
@@ -186,10 +186,11 @@ echo "Configuring Go environment"
 # a symlink is the appropriate way to "install" a specific version system-wide.
 #
 # Add upstream golang for perf issues
-curl -s -L https://golang.org/dl/go1.17.3.linux-amd64.tar.gz | \
+curl -s -L https://golang.org/dl/go1.18.4.linux-amd64.tar.gz | \
     $SUDO tar xzf - -C /usr/local/
 # Now linking to upstream golang until ubuntu performance issues are resolved
 $SUDO ln -sf /usr/local/go/bin/* /usr/bin/
+/usr/bin/go version  # make sure it can run
 
 chmod +x $SCRIPT_DIRPATH/podman_tooling.sh
 $SUDO bash $SCRIPT_DIRPATH/podman_tooling.sh


### PR DESCRIPTION
Upstream podman CI needs to update to a golang 1.18 minimum requirement.
Ensure that version is present in Ubuntu 22.04 images.  DO NOT produce
any prio-fedora images as testing there will be temporarily suspended
until the F37 timeframe.

**Note: Will be incorporated into #152**