### PR TITLE
[CI:DOCS] Fix oversight in image ID commenting bot

### DIFF
--- a/.github/workflows/pr_image_id.yml
+++ b/.github/workflows/pr_image_id.yml
@@ -55,16 +55,15 @@ jobs:
 
             - if: steps.retro.outputs.is_pr == 'true'
               name: Retrieve and process any manifest artifacts
-              env:
-                PODMAN: podman run --rm -v $PWD:/data -w /data
-                PR_CCIA: quay.io/libpod/ccia:c${{ steps.retro.outputs.bid }}
-                UP_CCIA: quay.io/libpod/ccia:latest
               # Use the CCIA image produce by the `Build Tooling images`
               # task of the PR we're looking at.  This allows testing
               # of changes to the CCIA container before merging into `main`
               # (where this workflow runs from).  If that should fail,
               # fall back to using the latest built CCIA image.
               run: |
+                PODMAN="podman run --rm -v $PWD:/data -w /data"
+                PR_CCIA="quay.io/libpod/ccia:c${{ steps.retro.outputs.bid }}"
+                UP_CCIA="quay.io/libpod/ccia:latest"
                 declare -a ARGS
                 ARGS=("--verbose" "${{ steps.retro.outputs.bid }}" ".*/manifest.json")
                 $PODMAN $PR_CCIA "${ARGS[@]}" || $PODMAN $UP_CCIA "${ARGS[@]}"


### PR DESCRIPTION
Apparently in github actions workflow, nested env. vars. do not resolve
like they do in Cirrus-CI.  Fix this.

Signed-off-by: Chris Evich <cevich@redhat.com>