### PR TITLE
[CI:TOOLING] Update imgts version-regex

### DIFF
--- a/imgts/entrypoint.sh
+++ b/imgts/entrypoint.sh
@@ -89,7 +89,7 @@ $result"
     tag=$(jq --raw-output "${prefix}.tag" <<<"$result" | sed 's/null//g')
 
     # Cirrus-CI sets `branch=pull/#` for pull-requests, dependabot creates
-    if [[ -z "$tag" && "$branch" =~ ^(v|release-)[0-9]+.* ]]; then
+    if [[ -z "$tag" && "$branch" =~ ^(v|release-)v?[0-9]+.* ]]; then
         msg "Found build $buildId for release branch '$branch'."
         return 0
     fi


### PR DESCRIPTION
While going through all the containers release-branches, I noticed some
repos use `release-X.Y` and others use `release-vX.Y`.  Update the imgts
version-detection regex accordingly.

Signed-off-by: Chris Evich <cevich@redhat.com>