### PR TITLE
[CI:DOCS] GHA: Re-use identical workflow from buildah repo

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -1,102 +1,17 @@
 ---
 
-# See also:
-# https://github.com/containers/podman/blob/main/.github/workflows/check_cirrus_cron.yml
-
-# Format Ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
-
-# Required to un-FUBAR default ${{github.workflow}} value
-name: check_cirrus_cron
-
 on:
-    # Note: This only applies to the default branch.
-    schedule:
-        # N/B: This should correspond to a period slightly after
-        # the last job finishes running.  See job defs. at:
-        # https://cirrus-ci.com/settings/repository/6680102350094336
-        - cron:  '59 23 * * 1-5'
-    # Debug: Allow triggering job manually in github-actions WebUI
-    workflow_dispatch: {}
-
-env:
-    # Debug-mode can reveal secrets, only enable by a secret value.
-    # Ref: https://help.github.com/en/actions/configuring-and-managing-workflows/managing-a-workflow-run#enabling-step-debug-logging
-    ACTIONS_STEP_DEBUG: '${{ secrets.ACTIONS_STEP_DEBUG }}'
-    # CSV listing of e-mail addresses for delivery failure or error notices
-    RCPTCSV: rh.container.bot@gmail.com,podman-monitor@lists.podman.io
-    # Filename for table of cron-name to build-id data
-    # (must be in $GITHUB_WORKSPACE/artifacts/)
-    NAME_ID_FILEPATH: './artifacts/name_id.txt'
+  # Note: This only applies to the default branch.
+  schedule:
+    # N/B: This should correspond to a period slightly after
+    # the last job finishes running.  See job defs. at:
+    # https://cirrus-ci.com/settings/repository/6680102350094336
+    - cron:  '59 23 * * 1-5'
+  # Debug: Allow triggering job manually in github-actions WebUI
+  workflow_dispatch: {}
 
 jobs:
-    cron_failures:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                  persist-credentials: false
-
-            # Avoid duplicating cron_failures.sh in buildah repo.
-            - uses: actions/checkout@v2
-              with:
-                  repository: containers/podman
-                  path: '_podman'
-                  persist-credentials: false
-
-            - name: Get failed cron names and Build IDs
-              id: cron
-              run: './_podman/.github/actions/${{ github.workflow }}/${{ github.job }}.sh'
-
-            - if: steps.cron.outputs.failures > 0
-              shell: bash
-              # Must be inline, since context expressions are used.
-              # Ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions
-              run: |
-                set -eo pipefail
-                (
-                echo "Detected one or more Cirrus-CI cron-triggered jobs have failed recently:"
-                echo ""
-
-                while read -r NAME BID; do
-                    echo "Cron build '$NAME' Failed: https://cirrus-ci.com/build/$BID"
-                done < "$NAME_ID_FILEPATH"
-
-                echo ""
-                echo "# Source: ${{ github.workflow }} workflow on ${{ github.repository }}."
-                # Separate content from sendgrid.com automatic footer.
-                echo ""
-                echo ""
-                ) > ./artifacts/email_body.txt
-
-            - if: steps.cron.outputs.failures > 0
-              name: Send failure notification e-mail
-              # Ref: https://github.com/dawidd6/action-send-mail
-              uses: dawidd6/action-send-mail@v2.2.2
-              with:
-                server_address: ${{secrets.ACTION_MAIL_SERVER}}
-                server_port: 465
-                username: ${{secrets.ACTION_MAIL_USERNAME}}
-                password: ${{secrets.ACTION_MAIL_PASSWORD}}
-                subject: Cirrus-CI cron build failures on ${{github.repository}}
-                to: ${{env.RCPTCSV}}
-                from: ${{secrets.ACTION_MAIL_SENDER}}
-                body: file://./artifacts/email_body.txt
-
-            - if: always()
-              uses: actions/upload-artifact@v2
-              with:
-                  name: ${{ github.job }}_artifacts
-                  path: artifacts/*
-
-            - if: failure()
-              name: Send error notification e-mail
-              uses: dawidd6/action-send-mail@v2.2.2
-              with:
-                server_address: ${{secrets.ACTION_MAIL_SERVER}}
-                server_port: 465
-                username: ${{secrets.ACTION_MAIL_USERNAME}}
-                password: ${{secrets.ACTION_MAIL_PASSWORD}}
-                subject: Github workflow error on ${{github.repository}}
-                to: ${{env.RCPTCSV}}
-                from: ${{secrets.ACTION_MAIL_SENDER}}
-                body: "Job failed: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
+  # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+  call_cron_failures:
+    uses: containers/buildah/.github/workflows/check_cirrus_cron.yml@main
+    secrets: inherit


### PR DESCRIPTION
It's a PITA to maintain duplicate code across repos.  Relatively
github-actions added a feature that allows re-using workflows
from other repos.  Use that here to reduce duplication.

Signed-off-by: Chris Evich <cevich@redhat.com>