### PR TITLE
[CI:TOOLING] Add support for AMI name-tag search

### DIFF
--- a/get_ci_vm/good_repo_test_v2/.cirrus.yml
+++ b/get_ci_vm/good_repo_test_v2/.cirrus.yml
@@ -4,7 +4,7 @@ aws_test_task:
     env:
         EC2_INST_TYPE: bigone.supervm
     ec2_instance:
-        image: ami-1234567890
+        image: fedora-podman-aws-arm64-c5495735033528320
         type: ${EC2_INST_TYPE}
 
 google_test_task:

--- a/get_ci_vm/good_repo_test_v2/ami_search.json
+++ b/get_ci_vm/good_repo_test_v2/ami_search.json
@@ -1,0 +1,32 @@
+{
+  "Images": [
+    {
+      "CreationDate": "2022-08-30T22:22:22.000Z",
+      "ImageId": "ami-unavailable",
+      "State": "some-random-state",
+      "Name": "fedora-podman-aws-arm64-c5495735033528320"
+    },
+    {
+      "CreationDate": "2020-01-01T01:01:01.000Z",
+      "ImageId": "ami-oldest",
+      "State": "available",
+      "Name": "fedora-podman-aws-arm64-c5495735033528320"
+    },
+    {
+      "CreationDate": "2022-07-25T19:34:17.000Z",
+      "ImageId": "ami-newest",
+      "State": "available",
+      "Name": "fedora-podman-aws-arm64-c5495735033528320"
+    },
+    {
+        "key": "Garbage",
+        "val": "Junk Data"
+    },
+    {
+      "CreationDate": "2022-07-25T07:34:17.000Z",
+      "ImageId": "ami-almost-newest",
+      "State": "available",
+      "Name": "fedora-podman-aws-arm64-c5495735033528320"
+    }
+  ]
+}

--- a/get_ci_vm/test.sh
+++ b/get_ci_vm/test.sh
@@ -304,10 +304,15 @@ testf "Verify mock 'ec2vm' w/o creds attempts to initialize" \
     init_ec2vm
 
 mock_init_aws() {
-    # Don't preserve arguments to make checking easier
-    # shellcheck disable=SC2145
-    echo "aws $@"
-    return 0
+    # Only care if string is present
+    # shellcheck disable=SC2199
+    if [[ "$@" =~ describe-images ]]; then
+        cat $GOOD_TEST_REPO_V2/ami_search.json
+    else
+        # Don't preserve arguments to make checking easier
+        # shellcheck disable=SC2145
+        echo "aws $@"
+    fi
 }
 
 mock_init_ec2vm() {
@@ -324,6 +329,16 @@ mock_init_ec2vm() {
 testf "Verify mock initialized 'ec2vm' is satisfied with test setup" \
     mock_init_ec2vm 0 "" \
     init_ec2vm
+
+print_select_ec2_inst_image() {
+    export A_DEBUG=1
+    select_ec2_inst_image
+    echo "$INST_IMAGE"
+}
+
+testf "Verify AMI selection by name tag with from fake describe-images data" \
+    mock_init_ec2vm 0 "ami-newest" \
+    print_select_ec2_inst_image
 
 # TODO: Add more EC2 tests
 


### PR DESCRIPTION
In response to recently added support in Cirrus-CI.  This mimics its
behavior: Search for the most recent AMI by name-tag when the image name
does not look like `ami-*`.  Also added a test to verify the complex
result-parsing remains functional over time.

Manually verified this works with both an updated and older podman
repository.

Signed-off-by: Chris Evich <cevich@redhat.com>