### PR TITLE
[CI:TOOLING] Add EC2 instance support to orphanvms container

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -290,6 +290,27 @@ test_imgobsolete_task: &lifecycle_test
     script:  /usr/local/bin/entrypoint.sh;
 
 
+# Note: The production check using this container is defined in
+# .github/workflows/orphan_vms.yml because it sends e-mail.
+test_orphanvms_task:
+    <<: *lifecycle_test
+    name: "Test orphan VMs detection"
+    alias: test_orphanvms
+    skip: *ci_docs
+    container:
+        image: 'quay.io/libpod/orphanvms:c$IMG_SFX'
+        cpu: 2
+        memory: '2G'
+    env:
+        GCPJSON: ENCRYPTED[da5e70861e477e5b7e499381b90c4dfd915c91bd535e56564626565415258e42748dbf3031daf0e508647715b649aff7]
+        GCPNAME: ENCRYPTED[cfb1c7fc976ab83c8d9b32ca3fbcdf4c5bd7b11dd43ff2b8ad91685bed846e8a5502ba857a35f8128a9fba22a85384aa]
+        GCPPROJECT: 'libpod-218412'
+        GCPPROJECTS: 'libpod-218412' # value for testing, otherwise see gcpprojects.txt
+        AWSINI: ENCRYPTED[1ab89ff7bc1515dc964efe7ef6e094e01164ba8dd2e11c9a01259c6af3b3968ab841dbe473fe4ab5b573f2f5fa3653e8]
+        EVERYTHING: 1  # Alter age-limit from 3-days -> 3 seconds for a test-run.
+    script: /usr/local/bin/entrypoint.sh
+
+
 test_imgprune_task:
     <<: *lifecycle_test
     name: "Test obsolete image deletion"
@@ -409,6 +430,7 @@ success_task:
         - cache_images
         - imgts
         - test_imgobsolete
+        - test_orphanvms
         - cron_imgobsolete
         - test_imgprune
         - cron_imgprune

--- a/.github/workflows/orphan_vms.yml
+++ b/.github/workflows/orphan_vms.yml
@@ -44,6 +44,7 @@ jobs:
                     GCPPROJECTS=$(egrep -vx '^#+.*$' $GITHUB_WORKSPACE/gcpprojects.txt | tr -s '[:space:]' ' ')
                     GCPNAME=${{ secrets.GCPNAME }}
                     GCPJSON=${{ secrets.GCPJSON }}
+                    AWSINI=${{ secrets.AWSINI }}
                 EOF
                 podman run --rm \
                     --env-file=$env_file \

--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ $(_TEMPDIR)/gcsupld.tar: $(_TEMPDIR)/imgts.tar imgts/lib_entrypoint.sh gcsupld/C
 
 .PHONY: orphanvms
 orphanvms: $(_TEMPDIR)/orphanvms.tar  ## Build the Orphaned VM container image
-$(_TEMPDIR)/orphanvms.tar: $(_TEMPDIR)/imgts.tar imgts/lib_entrypoint.sh orphanvms/Containerfile orphanvms/entrypoint.sh $(_TEMPDIR)/.cache/centos
+$(_TEMPDIR)/orphanvms.tar: $(_TEMPDIR)/imgts.tar imgts/lib_entrypoint.sh orphanvms/Containerfile orphanvms/entrypoint.sh orphanvms/_gce orphanvms/_ec2 $(_TEMPDIR)/.cache/centos
 	$(call imgts_base_podman_build,orphanvms)
 
 .PHONY: .get_ci_vm

--- a/imgts/Containerfile
+++ b/imgts/Containerfile
@@ -3,7 +3,8 @@ FROM quay.io/centos/centos:stream8
 # Only needed for installing build-time dependencies
 COPY /imgts/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
 RUN dnf -y --setopt=keepcache=true update && \
-    dnf -y --setopt=keepcache=true install epel-release python3 jq && \
+    dnf -y --setopt=keepcache=true install epel-release && \
+    dnf -y --setopt=keepcache=true install python3 jq awscli && \
     dnf -y --setopt=keepcache=true --exclude=google-cloud-sdk-366.0.0-1 \
         install google-cloud-sdk
 

--- a/imgts/entrypoint.sh
+++ b/imgts/entrypoint.sh
@@ -4,6 +4,9 @@
 # entrypoint. It's purpose is to operate on a list of VM Images, adding
 # metadata to each.  It must be executed alongside any repository's
 # automation, which produces or uses GCP VM Images.
+#
+# N/B: Timestamp updating is not required for AWS EC2 images as they
+# have a 'LastLaunchedTime' attribute which is updated automatically.
 
 set -e
 

--- a/orphanvms/Containerfile
+++ b/orphanvms/Containerfile
@@ -1,13 +1,12 @@
 FROM imgts:latest
 
-COPY /orphanvms/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY /orphanvms/entrypoint.sh /orphanvms/_gce /orphanvms/_ec2 /usr/local/bin/
 RUN chmod 755 /usr/local/bin/entrypoint.sh
 
-# These are only needed by imgts
+# Clear unneeded requirements, add GCPPROJECTS and AWSINI as required
 ENV GCPPROJECT="" \
     IMGNAMES="" \
     BUILDID="" \
-    REPOREF=""
-
-# This is an additional requirement
-ENV GCPPROJECTS="__unknown__"
+    REPOREF="" \
+    GCPPROJECTS="__unknown__" \
+    AWSINI="__unknown__"

--- a/orphanvms/_ec2
+++ b/orphanvms/_ec2
@@ -1,0 +1,110 @@
+
+
+# This script is intended to be sourced by entrypoint.sh.  It contains
+# all the Elastic-Compute-Cloud specific definitions and behaviors.
+# Anything written to stdout will end up in a notification e-mail.
+
+# This is just creating a temporary file and setting a env. var.  It should
+# not produce any output (which may needlessly trigger an e-mail).
+aws_init
+
+# Override this for debugging
+AWS="${AWS:-aws}"
+
+OUTPUT=$(mktemp -p '' orphanvms_awsec2_XXXXX)
+
+# It's simpler to compare unix times
+UNIX_THRESHOLD=$(date --date "$THRESHOLD" +%s)
+# EC2 instances can be in several transititory "meta" states, including
+# "terminated" (deleted).  This script only cares about "running" instances.
+EC2_FILTER="Name=instance-state-name,Values=running"
+# aws cli returns a giant blob of JSON with all kinds of details we don't care about.
+# Help cut down the amount of crap we need to stort through.
+EC2_QUERY="Reservations[*].Instances[*].{ID:InstanceId,TAGS:Tags,START:LaunchTime}"
+
+# Prints the value of a tag if it exists, otherwise prints nothing and returns 1.
+# First arg is the tag name, second arg is one instance object formed by $EC2_QUERY
+get_instance_tag() {
+    local tag=$1
+    local instance=$2
+    req_env_var tag instance
+    # Careful, there may not be any tag-list at all.
+    local tag_filter=".[]? | select(.Key == \"$tag\").Value"
+    local tags value
+
+    if tags=$(jq -e ".TAGS?"<<<"$instance"); then
+        # All tags are optional, the one we're looking for may not be set
+        if value=$(jq -e -r "$tag_filter"<<<"$tags") && [[ -n "$value" ]]; then
+            printf "$value"
+            return 0
+        fi
+    fi
+    return 1
+}
+
+echo "Orphaned AWS EC2 VMs:" > $OUTPUT
+
+# Returns an empty list when nothing is found, otherwise returns items indicated
+# in $EC2_QUERY, each inside a (useless) single-item list, inside another list.
+if ! aws_output=$(aws ec2 describe-instances --no-paginate --output json --filter "$EC2_FILTER" --query "$EC2_QUERY"); then
+    die 1 "Querying running EC2 instances: $aws_output"
+fi
+
+# Unroll the (useless) inner lists, if outer list is empty no instances were found.
+if ! simple_inst_list=$(jq -e '[.[][]]'<<<"$aws_output"); then
+    # Debug the original output in case it's more helpful
+    dbg "No EC2 instances found: $aws_output"
+    exit 0
+fi
+
+# I don't expect there will ever be more than maybe 0-20 instances at any time.
+for instance_index in $(seq 1 $(jq -e 'length'<<<"$simple_inst_list")); do
+    instance=$(jq -e ".[$instance_index - 1]"<<<"$simple_inst_list")
+    # A Name-tag isn't guaranteed, default to stupid, unreadable, generated ID
+    name=$(jq -r ".ID"<<<"$instance")
+    if name_tag=$(get_instance_tag "Name" "$instance"); then
+        # This is MUCH more human-friendly and easier to find in the WebUI.
+        # If it was an instance leaked by Cirrus-CI, it may even include the
+        # task number which leaked it.
+        name=$name_tag
+    fi
+
+    # The `START` (a.k.a. `LaunchTime`) value is documented as ISO 8601 format,
+    # forced to the UTC zone with a (useless) microseconds appended.  I found
+    # `jq` cannot parse the microseconds part properly, but `date` seems happy
+    # to accept it.
+    if ! started_at=$(date --utc --date $(jq -r -e ".START"<<<"$instance") +%s); then
+        die "Error extracting start time from instance JSON: '$instance'"
+    fi
+    age_days=$((($NOW - $started_at) / (60 * 60 * 24)))
+    if [[ $started_at -gt $UNIX_THRESHOLD ]]; then
+        dbg "Ignoring instance '$name' (too new)"
+        continue
+    fi
+
+    dbg "Examining EC2 instance '$name', '$age_days' days old"
+
+    if [[ $(get_instance_tag "persistent" "$instance" || true) == "true" ]]; then
+        dbg "Found instance '$name' marked persistent=true, ignoring it."
+        continue
+    fi
+
+    line="* VM $name running $age_days days"
+
+    # It would be nice to list all the tags like we do for GCE VMs,
+    # but it's a PITA to do for AWS in a human-readable format.
+    # Only print this handy-one (set by get_ci_vm) if it's there.
+    if inuseby_tag=$(get_instance_tag "in-use-by" "$instance"); then
+        dbg "Found instance '$name' tagged in-use-by=$inuseby_tag."
+        line+=" tagged in-use-by=$inuseby_tag"
+    fi
+
+    echo "$line" >> "$OUTPUT"
+done
+
+dbg "The following will be part of a notification e-mail:"
+
+# Don't count the "Orphaned AWS EC2 VMs:" header-line
+if [[ $(wc -l $OUTPUT | awk '{print $1}') -gt 1 ]]; then
+    cat $OUTPUT
+fi

--- a/orphanvms/_gce
+++ b/orphanvms/_gce
@@ -1,0 +1,52 @@
+
+
+# This script is intended to be sourced by entrypoint.sh.  It contains
+# all the Google-cloud-engine specific definitions and behaviors
+# Anything written to stdout will end up in a notification e-mail.
+
+# Try not to make any output when no orphan VMs are found
+GCLOUD="$GCLOUD --quiet --verbosity=error"
+# Format Ref: https://cloud.google.com/sdk/gcloud/reference/topic/formats
+FORMAT='value[quote](name,lastStartTimestamp,labels)'
+# Filter Ref: https://cloud.google.com/sdk/gcloud/reference/topic/filters
+# List fields cmd: `gcloud compute instances list --format=yaml --limit=1`
+FILTER="status!=TERMINATED AND lastStartTimestamp<$THRESHOLD AND labels.list(show='persistent')!~'true'"
+
+# Despite the --quiet flag, this will still emit 'Activated service account...'
+# to stdout.  Since stdout triggers the nag-email to  be sent, we must filter
+# only non-matching output.  Unfortunately, if if there is no output for some
+# reason, this will cause grep to fail.  Ignore this, since the next gcloud
+# command to follow will complain loudly if the credentials aren't sufficient.
+gcloud_init |& grep -Eiv '^Activated service account credentials for:' || true
+
+# shellcheck disable=SC2154,SC2153
+for GCPPROJECT in $GCPPROJECTS; do
+    dbg "Examining $GCPPROJECT"
+    OUTPUT=$(mktemp -p '' orphanvms_${GCPPROJECT}_XXXXX)
+    echo "Orphaned $GCPPROJECT VMs:" > $OUTPUT
+
+    # Ref: https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#deprecating_an_image
+    $GCLOUD compute instances list --format="$FORMAT" --filter="$FILTER" | \
+        while read name lastStartTimestamp labels
+        do
+            dbg "VM $name started $lastStartTimestamp labeled $labels"
+            if [[ -z "$name" ]] || [[ -z "$lastStartTimestamp" ]]; then
+                dbg "IGNORING EMPTY NAME OR TIMESTAMP"
+                continue
+            fi
+            started_at=$(date --date=$lastStartTimestamp +%s)
+            age_days=$((($NOW - $started_at) / (60 * 60 * 24)))
+            # running in a child-process, must buffer into file.
+            line="* VM $name running $age_days days"
+            if [[ -n "$labels" ]]; then
+                line+=" with labels '$labels'"
+            fi
+            dbg "FLAGGING VM AS ORPHANED"
+            echo "$line" >> $OUTPUT
+        done
+
+    if [[ $(wc -l $OUTPUT | awk '{print $1}') -gt 1 ]]; then
+        dbg "The following will be part of a notification e-mail for ($GCPPROJECT):"
+        cat $OUTPUT
+    fi
+done

--- a/orphanvms/entrypoint.sh
+++ b/orphanvms/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # This script is set as, and intended to run as the `orphanvms` container's
-# entrypoint.  It searches for actibe VM instances with an "old" `creation`
-# timestamp.
+# entrypoint.  It searches for active VM instances with an "old" `creation`
+# timestamp - where "old" is a completely arbitrary several days :)
 
 set -eo pipefail
 
@@ -12,57 +12,30 @@ source /usr/local/bin/lib_entrypoint.sh
 # set this to 1 to enable
 A_DEBUG="${A_DEBUG:-0}"
 if ((A_DEBUG)); then msg "Warning: Debugging is enabled"; fi
-EVERYTHING=${EVERYTHING:-0}  # set to '1' for testing
 
-req_env_var GCPJSON GCPNAME GCPPROJECTS
+req_env_var GCPJSON GCPNAME GCPPROJECTS AWSINI
 
-# Try not to make any output when no orphan VMs are found
-GCLOUD="$GCLOUD --quiet --verbosity=error"
+NOW=$(date +%s)
 TOO_OLD='3 days ago'  # Detect Friday Orphans on Monday
+EVERYTHING=${EVERYTHING:-0}  # set to '1' for testing
 if ((EVERYTHING)); then
     TOO_OLD="3 seconds ago"
 fi
-
-NOW=$(date +%s)
+# Anything older than this is "too old"
 THRESHOLD=$(date --date="$TOO_OLD" --iso-8601=minute)
-# Format Ref: https://cloud.google.com/sdk/gcloud/reference/topic/formats
-FORMAT='value[quote](name,lastStartTimestamp,labels)'
-# Filter Ref: https://cloud.google.com/sdk/gcloud/reference/topic/filters
-# List fields cmd: `gcloud compute instances list --format=yaml --limit=1`
-FILTER="status!=TERMINATED AND lastStartTimestamp<$THRESHOLD AND labels.list(show='persistent')!~'true'"
 
-# shellcheck disable=SC2154,SC2153
-for GCPPROJECT in $GCPPROJECTS; do
-    # Despite the --quiet flag, this will still emit 'Activated service account...'
-    # to stdout.  Since stdout triggers the nag-email to  be sent, we must filter
-    # only non-matching output.  Unfortunately, if if there is no output for some
-    # reason, this will cause grep to fail.  Ignore this, since the next gcloud
-    # command to follow will complain loudly if the credentials aren't sufficient.
-    gcloud_init |& grep -Eiv '^Activated service account credentials for:' || true
-
-    if ((A_DEBUG)); then msg "Examining $GCPPROJECT"; fi
-    OUTPUT=$(mktemp -p '' orphanvms_${GCPPROJECT}_XXXXX)
-    echo "Orphaned $GCPPROJECT VMs:" > $OUTPUT
-
-    # Ref: https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#deprecating_an_image
-    $GCLOUD compute instances list --format="$FORMAT" --filter="$FILTER" | \
-        while read name lastStartTimestamp labels
-        do
-            if ((A_DEBUG)); then
-                msg "    VM $name started $lastStartTimestamp labeled $labels"
-            fi
-            if [[ -z "$name" ]] || [[ -z "$lastStartTimestamp" ]]; then
-                if ((A_DEBUG)); then msg "    IGNORING EMPTY NAME OR TIMESTAMP"; fi
-                continue
-            fi
-            started_at=$(date --date=$lastStartTimestamp +%s)
-            age_days=$((($NOW - $started_at) / (60 * 60 * 24)))
-            # running in a child-process, must buffer into file.
-            echo -e "* VM $name running $age_days days with labels '$labels'" >> $OUTPUT
-            if ((A_DEBUG)); then msg "    FLAGGING VM AS ORPHANED"; fi
-        done
-
-    if [[ $(wc -l $OUTPUT | awk '{print $1}') -gt 1 ]]; then
-        cat $OUTPUT
+dbg() {
+    if ((A_DEBUG)); then
+        (
+        echo
+        # There's lots of looping going on in this script with left-justified output.
+        # Offset debugging messages so they have more context.
+        echo "    ${1:-No debugging message given}"
+        ) > /dev/stderr
     fi
-done
+}
+
+# shellcheck source=orphanvms/gce
+. /usr/local/bin/_gce
+# shellcheck source=orphanvms/ec2
+. /usr/local/bin/_ec2


### PR DESCRIPTION

VM's come from many sources (i.e. cirrus-CI, get_ci_vm, manually created, etc.).
Some VMs are quite costly to run, others hanging around may indicate an
automation or security-related problem.  So it makes sense to monitor for
any VMs hanging around more than several days.

Update the `imgts` (base) image to include the `aws` CLI tool.  Enhance
the orphanvms container image (and scripts) to print out a
human-friendly list of VMs which may have leaked.  The
github-actions-workflow `orphan_vms.yml` will run this container daily
and send an e-mail to podman-monitor with any standard-output.