### PR TITLE
Support optional EC2 images in imgts container

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -233,27 +233,30 @@ cache_images_task:
         type: application/json
 
 
-# Test both metadata addition to newly built images, and ensure container functions
-imgts_task:
-    name: "Apply new image metadata"
-    alias: imgts
-    only_if: *is_pr
-    skip: *ci_docs_tooling
+# Test metadata addition to images (built or not) to ensure container functions
+# TODO: Requires manually examining the output log to confirm operation.
+test_imgts_task: &imgts
+    name: "Test image timestamp/metadata updates"
+    alias: test_imgts
+    only_if: $CIRRUS_CRON == ''
+    skip: *ci_docs
     depends_on:
-        - base_images
-        - cache_images
+        - tooling_images
     container:
         image: 'quay.io/libpod/imgts:c$IMG_SFX'
         cpu: 2
         memory: '2G'
-    env:
-        # Not all $IMGNAMES may have been built, don't fail if some are missing
-        REQUIRE_ALL: 0  # This should ONLY be set `0` on this repository!
+    env: &imgts_env
+        DRY_RUN: 1  # Don't actually touch images
         BUILDID: "$CIRRUS_BUILD_ID"
         REPOREF: "$CIRRUS_REPO_NAME"
-        GCPJSON: ENCRYPTED[112c55192dba9a7edd1889a7e704aa1e6ae40730b97ad8ebcbae2bb5f4ff84c7e9ca5b955baaf1f69e7b9e5c5a14a4d3]
-        GCPNAME: ENCRYPTED[93cad237544dbbd663874e6896cd9c50a708e87d2cd40724c8b6c18237f4e2d40fd5e3c4a1fdbf7dafac3ceadf69a1c1]
-        GCPPROJECT: 'libpod-218412'
+        GCPJSON: "gobldygook"
+        GCPNAME: "TestyMcTestface"
+        GCPPROJECT: "Amazon-web-services"
+        AWSINI: "Bill Gates"
+        # This task is just a test, but were images actually built
+        # the `imgts_task` below will re-use these names and actually
+        # attempt to update them.
         IMGNAMES: |
             image-builder-${IMG_SFX}
             fedora-b${IMG_SFX}
@@ -265,8 +268,37 @@ imgts_task:
             fedora-podman-py-c${IMG_SFX}
             ubuntu-c${IMG_SFX}
             build-push-c${IMG_SFX}
+        EC2IMGNAMES: |
+            fedora-aws-b${IMG_SFX}
+            fedora-aws-c${IMG_SFX}
+            fedora-aws-arm64-b${IMG_SFX}
+            fedora-podman-aws-arm64-c${IMG_SFX}
+            fedora-netavark-aws-arm64-c${IMG_SFX}
     clone_script: &noop mkdir -p "${CIRRUS_WORKING_DIR}"  # source is not needed
     script: "/usr/local/bin/entrypoint.sh"
+
+
+# Actual metadata update to any built images
+imgts_task:
+    <<: *imgts
+    name: "Update image timestamp/metadata"
+    alias: imgts
+    only_if: *is_pr
+    skip: *ci_docs_tooling
+    depends_on:
+        - base_images
+        - cache_images
+    env:
+        <<: *imgts_env
+        DRY_RUN: 0
+        # Not all $IMGNAMES may have been built, don't fail if some are missing
+        # This should ONLY be set `0` on this repository!  There may be
+        # zero or more no_FOO labels on the PR to block building certain images.
+        REQUIRE_ALL: 0  # This should ONLY be set `0` on this repository!
+        GCPJSON: ENCRYPTED[112c55192dba9a7edd1889a7e704aa1e6ae40730b97ad8ebcbae2bb5f4ff84c7e9ca5b955baaf1f69e7b9e5c5a14a4d3]
+        GCPNAME: ENCRYPTED[93cad237544dbbd663874e6896cd9c50a708e87d2cd40724c8b6c18237f4e2d40fd5e3c4a1fdbf7dafac3ceadf69a1c1]
+        GCPPROJECT: 'libpod-218412'
+        AWSINI: ENCRYPTED[406795b7eee55fcedde37e0b4d7a5070f447f7dc9d8d6c4a1eec0d2592aa94b019b45b730ba1a2acb1a1ef0040561e2b]
 
 
 test_imgobsolete_task: &lifecycle_test
@@ -428,6 +460,7 @@ success_task:
         - tooling_images
         - base_images
         - cache_images
+        - test_imgts
         - imgts
         - test_imgobsolete
         - test_orphanvms

--- a/gcsupld/entrypoint.sh
+++ b/gcsupld/entrypoint.sh
@@ -10,7 +10,7 @@ set -eo pipefail
 # shellcheck source=imgts/lib_entrypoint.sh
 source /usr/local/bin/lib_entrypoint.sh
 
-req_env_var GCPJSON GCPNAME GCPPROJECT FROM_FILEPATH TO_GCSURI
+req_env_vars GCPJSON GCPNAME GCPPROJECT FROM_FILEPATH TO_GCSURI
 
 # shellcheck disable=SC2154
 msg "Will upload '$FROM_FILEPATH' to '$TO_GCSURI'"

--- a/imgobsolete/entrypoint.sh
+++ b/imgobsolete/entrypoint.sh
@@ -11,7 +11,7 @@ set -e
 # shellcheck source=imgts/lib_entrypoint.sh
 source /usr/local/bin/lib_entrypoint.sh
 
-req_env_var GCPJSON GCPNAME GCPPROJECT
+req_env_vars GCPJSON GCPNAME GCPPROJECT
 
 gcloud_init
 

--- a/imgprune/entrypoint.sh
+++ b/imgprune/entrypoint.sh
@@ -11,7 +11,7 @@ set -e
 # shellcheck source=imgts/lib_entrypoint.sh
 source /usr/local/bin/lib_entrypoint.sh
 
-req_env_var GCPJSON GCPNAME GCPPROJECT
+req_env_vars GCPJSON GCPNAME GCPPROJECT
 
 gcloud_init
 

--- a/imgts/Containerfile
+++ b/imgts/Containerfile
@@ -8,13 +8,16 @@ RUN dnf -y --setopt=keepcache=true update && \
     dnf -y --setopt=keepcache=true --exclude=google-cloud-sdk-366.0.0-1 \
         install google-cloud-sdk
 
-# These all represent required variables which must be set by caller
+# Env. vars set to "__unknown__" are required to be set by the caller;
+# Except, an AWSINI value is required if EC2IMGNAMES is non-empty.
 ENV GCPJSON="__unknown__" \
     GCPNAME="__unknown__" \
     GCPPROJECT="__unknown__" \
     IMGNAMES="__unknown__" \
     BUILDID="__unknown__" \
-    REPOREF="__unknown__"
+    REPOREF="__unknown__" \
+    EC2IMGNAMES="" \
+    AWSINI=""
 
 COPY ["/imgts/entrypoint.sh", "/imgts/lib_entrypoint.sh", "/usr/local/bin/"]
 RUN chmod 755 /usr/local/bin/entrypoint.sh

--- a/imgts/entrypoint.sh
+++ b/imgts/entrypoint.sh
@@ -3,19 +3,19 @@
 # This script is set as, and intended to run as the `imgts` container's
 # entrypoint. It's purpose is to operate on a list of VM Images, adding
 # metadata to each.  It must be executed alongside any repository's
-# automation, which produces or uses GCP VM Images.
+# automation, which produces or uses GCP VMs and/or AWS EC2 instances.
 #
 # N/B: Timestamp updating is not required for AWS EC2 images as they
 # have a 'LastLaunchedTime' attribute which is updated automatically.
+# However, updating their permanent=true tag (when appropriate) and
+# a reference to the build ID and repo name are all useful.
 
 set -e
 
-# shellcheck source=./lib_entrypoint.sh
+# shellcheck source=imgts/lib_entrypoint.sh
 source /usr/local/bin/lib_entrypoint.sh
 
 req_env_vars GCPJSON GCPNAME GCPPROJECT IMGNAMES BUILDID REPOREF
-
-gcloud_init
 
 # Set this to 1 for testing
 DRY_RUN="${DRY_RUN:-0}"
@@ -107,14 +107,21 @@ if is_release_branch_image $BUILDID; then
     SET_PERM=1
 fi
 
-if ((DRY_RUN)); then GCLOUD='echo'; fi
+if ((DRY_RUN)); then
+    GCLOUD="echo $GCLOUD"
+    AWS="echo $AWS"
+    DRPREFIX="DRY-RUN: "
+else
+    # This outputs a status message to stderr
+    gcloud_init
+fi
 
 # Must be defined by the cirrus-ci job using the container
 # shellcheck disable=SC2154
 for image in $IMGNAMES
 do
     if ! OUTPUT=$($GCLOUD compute images update "$image" "${ARGS[@]}" 2>&1); then
-        echo "$OUTPUT" > /dev/stderr
+        msg "$OUTPUT"
         if grep -iq "$CLASHMSG" <<<"$OUTPUT"; then
             # Updating the 'last-used' label is most important.
             # Assume clashing update did this for us.
@@ -122,16 +129,60 @@ do
             continue
         fi
         msg "Detected update error for '$image'" > /dev/stderr
-        ERRIMGS="$ERRIMGS $image"
+        ERRIMGS+=" $image"
     else
         # Display the URI to the updated image for reference
         if ((SET_PERM)); then
-            msg "IMAGE $image MARKED FOR PERMANENT RETENTION"
+            msg "${DRPREFIX}IMAGE $image MARKED FOR PERMANENT RETENTION"
         else
-            echo "Updated image $image last-used timestamp"
+            msg "${DRPREFIX}Updated image $image last-used timestamp"
         fi
     fi
 done
+
+# Not all repos use EC2 instances, only touch AWS if both
+# EC2IMGNAMES and AWSINI are set.
+if [[ -n "$EC2IMGNAMES" ]]; then
+    msg "---"
+    req_env_vars AWSINI BUILDID REPOREF
+
+    if ! ((DRY_RUN)); then
+        aws_init
+        # aws_init() has no output because that would break in other contexts.
+        msg "Activated AWS CLI for service acount."
+    fi
+
+    for image in $EC2IMGNAMES; do
+        if ((DRY_RUN)); then
+            # AWS=echo; no lookup will actually happen
+            amiid="dry-run-$image"
+        elif ! amiid=$(get_ec2_ami "$image"); then
+            ERRIMGS+=" $image"
+            continue
+        fi
+
+        # AWS deliberately left unquoted for intentional word-splitting.
+        # N/B: For $DRY_RUN==1: AWS=echo
+        # shellcheck disable=SC2206
+        awscmd=(\
+            $AWS ec2 create-tags
+            --resources "$amiid" --tags
+            "Key=build-id,Value=$BUILDID"
+            "Key=repo-ref,Value=$REPOREF"
+        )
+        if ((SET_PERM)); then
+            awscmd+=("Key=permanent,Value=true")
+        fi
+
+        if ! OUTPUT=$("${awscmd[@]}"); then
+            ERRIMGS+=" $image"
+        elif ((SET_PERM)); then
+            msg "${DRPREFIX}IMAGE $image ($amiid) MARKED FOR PERMANENT RETENTION"
+        else
+            msg "${DRPREFIX}Updated image $image ($amiid) metadata."
+        fi
+    done
+fi
 
 if [[ -n "$ERRIMGS" ]]; then
     die_or_warn=die

--- a/imgts/entrypoint.sh
+++ b/imgts/entrypoint.sh
@@ -13,7 +13,7 @@ set -e
 # shellcheck source=./lib_entrypoint.sh
 source /usr/local/bin/lib_entrypoint.sh
 
-req_env_var GCPJSON GCPNAME GCPPROJECT IMGNAMES BUILDID REPOREF
+req_env_vars GCPJSON GCPNAME GCPPROJECT IMGNAMES BUILDID REPOREF
 
 gcloud_init
 

--- a/imgts/lib_entrypoint.sh
+++ b/imgts/lib_entrypoint.sh
@@ -36,7 +36,7 @@ msg() {
 
 # Pass in a list of one or more envariable names; exit non-zero with
 # helpful error message if any value is empty
-req_env_var() {
+req_env_vars() {
     for i; do
         if [[ -z "${!i}" ]]
         then
@@ -49,7 +49,7 @@ req_env_var() {
 }
 
 gcloud_init() {
-    req_env_var GCPJSON GCPPROJECT
+    req_env_vars GCPJSON GCPPROJECT
     set +xe
     if [[ -n "$1" ]] && [[ -r "$1" ]]
     then
@@ -71,7 +71,7 @@ gcloud_init() {
 }
 
 aws_init() {
-    req_env_var AWSINI
+    req_env_vars AWSINI
     set +xe
     if [[ -n "$1" ]] && [[ -r "$1" ]]
     then

--- a/orphanvms/_ec2
+++ b/orphanvms/_ec2
@@ -27,7 +27,7 @@ EC2_QUERY="Reservations[*].Instances[*].{ID:InstanceId,TAGS:Tags,START:LaunchTim
 get_instance_tag() {
     local tag=$1
     local instance=$2
-    req_env_var tag instance
+    req_env_vars tag instance
     # Careful, there may not be any tag-list at all.
     local tag_filter=".[]? | select(.Key == \"$tag\").Value"
     local tags value

--- a/orphanvms/entrypoint.sh
+++ b/orphanvms/entrypoint.sh
@@ -13,7 +13,7 @@ source /usr/local/bin/lib_entrypoint.sh
 A_DEBUG="${A_DEBUG:-0}"
 if ((A_DEBUG)); then msg "Warning: Debugging is enabled"; fi
 
-req_env_var GCPJSON GCPNAME GCPPROJECT GCPPROJECTS AWSINI
+req_env_vars GCPJSON GCPNAME GCPPROJECT GCPPROJECTS AWSINI
 
 NOW=$(date +%s)
 TOO_OLD='3 days ago'  # Detect Friday Orphans on Monday


### PR DESCRIPTION
AWS EC2 has a separate mechanism for recording an AMI's last-used
timestamp.  However, other important metadata is also maintained on
images such as `permanent=true` (or not).  For repos. which utilize EC2,
add support for the imgts container updating EC2 images metadata.

Also, add a task to exercise the imgts container in a [CI:TOOLING]
context (where the image is built).  Set this up as a dry-run
so it doesn't depend on the images actually existing.