### PR TITLE
[CI:TOOLING] Add EC2 imgobsolete container & cirrus-cron support 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -302,7 +302,7 @@ imgts_task:
 
 
 test_imgobsolete_task: &lifecycle_test
-    name: "Test old images obsolete marking"
+    name: "Test obsolete image detection"
     alias: test_imgobsolete
     only_if: &not_cron $CIRRUS_CRON == ''
     skip: *ci_docs
@@ -317,9 +317,10 @@ test_imgobsolete_task: &lifecycle_test
         GCPJSON: ENCRYPTED[a0482ce379d4fa3ea84b3fd6199cce75294262a65250c08ec9a5c454cbba06b7b55c8cdb43bbab2f6a81f3419096200e]
         GCPNAME: ENCRYPTED[57b2c60b8168a2dc6f281a31a051ffab069b3c05bd495f38c0d5178fdcfb9ac7e1295460d8c4beb979c88d88061fa463]
         GCPPROJECT: 'libpod-218412'
+        AWSINI: ENCRYPTED[0215d4bb3572d35351ddcffeee5f4103ee1baa07ef0de95a7cd92dae27c4a655dd7116f8f710c8e1820c704b6a7e9179]
         DRY_RUN: 1
     clone_script: *noop
-    script:  /usr/local/bin/entrypoint.sh;
+    script:  /usr/local/bin/entrypoint.sh
 
 
 # Note: The production check using this container is defined in
@@ -345,7 +346,7 @@ test_orphanvms_task:
 
 test_imgprune_task:
     <<: *lifecycle_test
-    name: "Test obsolete image deletion"
+    name: "Test obsolete image removal"
     alias: test_imgprune
     skip: *ci_docs
     depends_on:

--- a/imgobsolete/Containerfile
+++ b/imgobsolete/Containerfile
@@ -3,7 +3,8 @@ FROM imgts:latest
 COPY /imgobsolete/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod 755 /usr/local/bin/entrypoint.sh
 
-# These are only needed by imgts
-ENV IMGNAMES="" \
+# Env. vars set to "__unknown__" are required to be set by the caller
+ENV AWSINI="__unknown__" \
+    IMGNAMES="" \
     BUILDID="" \
     REPOREF=""

--- a/imgts/Containerfile
+++ b/imgts/Containerfile
@@ -1,12 +1,23 @@
 FROM quay.io/centos/centos:stream8
 
+ARG dnfycache="dnf -y --setopt=keepcache=true"
+
 # Only needed for installing build-time dependencies
 COPY /imgts/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
-RUN dnf -y --setopt=keepcache=true update && \
-    dnf -y --setopt=keepcache=true install epel-release && \
-    dnf -y --setopt=keepcache=true install python3 jq awscli && \
-    dnf -y --setopt=keepcache=true --exclude=google-cloud-sdk-366.0.0-1 \
+RUN ${dnfycache} update && \
+    ${dnfycache} install epel-release && \
+    ${dnfycache} install python3 jq && \
+    ${dnfycache} --exclude=google-cloud-sdk-366.0.0-1 \
         install google-cloud-sdk
+
+# https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+ARG AWSURL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+RUN ${dnfycache} install unzip glibc groff-base less && \
+    cd /tmp && \
+    curl --fail --location -O "${AWSURL}" && \
+    unzip awscli*.zip && \
+    ./aws/install -i /usr/local/share/aws-cli -b /usr/local/bin && \
+    rm -rf awscli*.zip ./aws
 
 # Env. vars set to "__unknown__" are required to be set by the caller;
 # Except, an AWSINI value is required if EC2IMGNAMES is non-empty.

--- a/orphanvms/_ec2
+++ b/orphanvms/_ec2
@@ -22,26 +22,6 @@ EC2_FILTER="Name=instance-state-name,Values=running"
 # Help cut down the amount of crap we need to stort through.
 EC2_QUERY="Reservations[*].Instances[*].{ID:InstanceId,TAGS:Tags,START:LaunchTime}"
 
-# Prints the value of a tag if it exists, otherwise prints nothing and returns 1.
-# First arg is the tag name, second arg is one instance object formed by $EC2_QUERY
-get_instance_tag() {
-    local tag=$1
-    local instance=$2
-    req_env_vars tag instance
-    # Careful, there may not be any tag-list at all.
-    local tag_filter=".[]? | select(.Key == \"$tag\").Value"
-    local tags value
-
-    if tags=$(jq -e ".TAGS?"<<<"$instance"); then
-        # All tags are optional, the one we're looking for may not be set
-        if value=$(jq -e -r "$tag_filter"<<<"$tags") && [[ -n "$value" ]]; then
-            printf "$value"
-            return 0
-        fi
-    fi
-    return 1
-}
-
 echo "Orphaned AWS EC2 VMs:" > $OUTPUT
 
 # Returns an empty list when nothing is found, otherwise returns items indicated
@@ -62,7 +42,7 @@ for instance_index in $(seq 1 $(jq -e 'length'<<<"$simple_inst_list")); do
     instance=$(jq -e ".[$instance_index - 1]"<<<"$simple_inst_list")
     # A Name-tag isn't guaranteed, default to stupid, unreadable, generated ID
     name=$(jq -r ".ID"<<<"$instance")
-    if name_tag=$(get_instance_tag "Name" "$instance"); then
+    if name_tag=$(get_tag_value "Name" "$instance"); then
         # This is MUCH more human-friendly and easier to find in the WebUI.
         # If it was an instance leaked by Cirrus-CI, it may even include the
         # task number which leaked it.
@@ -84,7 +64,7 @@ for instance_index in $(seq 1 $(jq -e 'length'<<<"$simple_inst_list")); do
 
     dbg "Examining EC2 instance '$name', '$age_days' days old"
 
-    if [[ $(get_instance_tag "persistent" "$instance" || true) == "true" ]]; then
+    if [[ $(get_tag_value "persistent" "$instance" || true) == "true" ]]; then
         dbg "Found instance '$name' marked persistent=true, ignoring it."
         continue
     fi
@@ -94,7 +74,7 @@ for instance_index in $(seq 1 $(jq -e 'length'<<<"$simple_inst_list")); do
     # It would be nice to list all the tags like we do for GCE VMs,
     # but it's a PITA to do for AWS in a human-readable format.
     # Only print this handy-one (set by get_ci_vm) if it's there.
-    if inuseby_tag=$(get_instance_tag "in-use-by" "$instance"); then
+    if inuseby_tag=$(get_tag_value "in-use-by" "$instance"); then
         dbg "Found instance '$name' tagged in-use-by=$inuseby_tag."
         line+=" tagged in-use-by=$inuseby_tag"
     fi


### PR DESCRIPTION

Every time images are built in this repo. it can be a dice-roll.
There's a decent possibility the build could fail or the images won't
meet the needs of downstream CI.  Additionally, when downstream CI
actually moves onto updates images, the old ones are left behind taking
up space.  Multiply this by all the repos using VMs, and it quickly
adds up to a lot of crap images hanging around.

Dealing with this mess is the job of the imgobsolete container image.
Add support to it for handling AWS EC2 images, including the required
special-handling for (release-branch) permanent=true images. Also update
the `test_imgobsolete` task to validate the changes actually functional.
Lastly, update the two related task-names to make them easier to
read/understand.