### PR TITLE
[CI:DOCS] Fix passing secret env. vars. into podman

### DIFF
--- a/.github/workflows/orphan_vms.yml
+++ b/.github/workflows/orphan_vms.yml
@@ -37,15 +37,13 @@ jobs:
                   persist-credentials: false
 
             - name: Collect listing of orphaned VMs
-              env:
-                GCPNAME: ${{ secrets.GCPNAME }}
-                GCPJSON: ${{ secrets.GCPJSON }}
-                AWSINI: ${{ secrets.AWSINI }}
               run: |
-                export GCPNAME GCPJSON AWSINI
-                export GCPPROJECTS=$(egrep -vx '^#+.*$' $GITHUB_WORKSPACE/gcpprojects.txt | tr -s '[:space:]' ' ')
+                GCPPROJECTS=$(egrep -vx '^#+.*$' $GITHUB_WORKSPACE/gcpprojects.txt | tr -s '[:space:]' ' ')
                 podman run --rm \
-                    -e GCPNAME -e GCPJSON -e AWSINI -e GCPPROJECTS \
+                    -e "GCPNAME=${{ secrets.GCPNAME }}" \
+                    -e "GCPJSON=${{ secrets.GCPJSON }}" \
+                    -e "AWSINI=${{ secrets.AWSINI }}" \
+                    -e "GCPPROJECTS=$GCPPROJECTS" \
                     quay.io/libpod/orphanvms:latest \
                     > tee /tmp/orphanvms_output.txt
 


### PR DESCRIPTION
Fix issue introduced in https://github.com/containers/automation_images/pull/171

At the time of this commit, the default github-action runners are using
an ancient version of podman.  This version does not support using the
`-e ENVAR` feature to slurp up env. var values from the environment.
They must be set on the command-line.