### PR TITLE
[CI:DOCS] Fix missing GCPPROJECT requirement in orphanvms

### DIFF
--- a/.github/workflows/orphan_vms.yml
+++ b/.github/workflows/orphan_vms.yml
@@ -41,12 +41,12 @@ jobs:
                 GCPNAME: ${{ secrets.GCPNAME }}
                 GCPJSON: ${{ secrets.GCPJSON }}
                 AWSINI: ${{ secrets.AWSINI }}
+                GCPPROJECT: 'libpod-218412'
               run: |
-                export GCPNAME GCPJSON AWSINI
+                export GCPNAME GCPJSON AWSINI GCPPROJECT
                 export GCPPROJECTS=$(egrep -vx '^#+.*$' $GITHUB_WORKSPACE/gcpprojects.txt | tr -s '[:space:]' ' ')
-                # TODO: `--env-host` is probably over-sharing, use `-e VAR` form
-                # when runner supports newer podman version than 3.4.4
-                podman run --rm --env-host \
+                podman run --rm \
+                    -e GCPNAME -e GCPJSON -e AWSINI -e GCPPROJECT -e GCPPROJECTS \
                     quay.io/libpod/orphanvms:latest \
                     > tee /tmp/orphanvms_output.txt
 

--- a/orphanvms/Containerfile
+++ b/orphanvms/Containerfile
@@ -4,8 +4,7 @@ COPY /orphanvms/entrypoint.sh /orphanvms/_gce /orphanvms/_ec2 /usr/local/bin/
 RUN chmod 755 /usr/local/bin/entrypoint.sh
 
 # Clear unneeded requirements, add GCPPROJECTS and AWSINI as required
-ENV GCPPROJECT="" \
-    IMGNAMES="" \
+ENV IMGNAMES="" \
     BUILDID="" \
     REPOREF="" \
     GCPPROJECTS="__unknown__" \

--- a/orphanvms/_gce
+++ b/orphanvms/_gce
@@ -20,10 +20,10 @@ FILTER="status!=TERMINATED AND lastStartTimestamp<$THRESHOLD AND labels.list(sho
 gcloud_init |& grep -Eiv '^Activated service account credentials for:' || true
 
 # shellcheck disable=SC2154,SC2153
-for GCPPROJECT in $GCPPROJECTS; do
-    dbg "Examining $GCPPROJECT"
-    OUTPUT=$(mktemp -p '' orphanvms_${GCPPROJECT}_XXXXX)
-    echo "Orphaned $GCPPROJECT VMs:" > $OUTPUT
+for gcpproject in $gcpprojectS; do
+    dbg "Examining $gcpproject"
+    OUTPUT=$(mktemp -p '' orphanvms_${gcpproject}_XXXXX)
+    echo "Orphaned $gcpproject VMs:" > $OUTPUT
 
     # Ref: https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#deprecating_an_image
     $GCLOUD compute instances list --format="$FORMAT" --filter="$FILTER" | \
@@ -46,7 +46,7 @@ for GCPPROJECT in $GCPPROJECTS; do
         done
 
     if [[ $(wc -l $OUTPUT | awk '{print $1}') -gt 1 ]]; then
-        dbg "The following will be part of a notification e-mail for ($GCPPROJECT):"
+        dbg "The following will be part of a notification e-mail for ($gcpproject):"
         cat $OUTPUT
     fi
 done

--- a/orphanvms/entrypoint.sh
+++ b/orphanvms/entrypoint.sh
@@ -13,7 +13,7 @@ source /usr/local/bin/lib_entrypoint.sh
 A_DEBUG="${A_DEBUG:-0}"
 if ((A_DEBUG)); then msg "Warning: Debugging is enabled"; fi
 
-req_env_var GCPJSON GCPNAME GCPPROJECTS AWSINI
+req_env_var GCPJSON GCPNAME GCPPROJECT GCPPROJECTS AWSINI
 
 NOW=$(date +%s)
 TOO_OLD='3 days ago'  # Detect Friday Orphans on Monday


### PR DESCRIPTION
This var. was always required by gcloud-init() but by re-initializing
inside a loop of other projects, gcloud apparently ignored it being an
incorrect value.  Clarify the situation by making the env. var. required
and changing the loop variable name to avoid any confusion.

This should hopefully/finally fix https://github.com/containers/automation_images/issues/173

Signed-off-by: Chris Evich <cevich@redhat.com>