### PR TITLE
Update package dependencies

### DIFF
--- a/cache_images/fedora_packaging.sh
+++ b/cache_images/fedora_packaging.sh
@@ -129,6 +129,7 @@ INSTALL_PACKAGES=(\
     python3-PyYAML
     python3-coverage
     python3-dateutil
+    python3-devel
     python3-docker
     python3-fixtures
     python3-libselinux
@@ -193,7 +194,6 @@ DOWNLOAD_PACKAGES=(\
     parallel
     podman-docker
     podman-plugins
-    podman-gvproxy
     python3-pytest
     python3-virtualenv
 )


### PR DESCRIPTION
Install python3-devel and do not download podman-* packages as they can
be fetched from dnf.

oci-umount should no longer be needed.

Fixes: #159 and #161

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>