### PR TITLE
[CI:DOCS] Overhaul image-table pr-comment workflow

### DIFF
--- a/.github/actions/bin/create_image_table.py
+++ b/.github/actions/bin/create_image_table.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+"""Parse /tmp/built_images.json into MD table in $IMAGE_TABLE"""
+
+# Note: This script is exclusively intended to be used by the
+# pr_image_id.yml github-actions workflow.  Any use outside that
+# context is unlikely to function as intended
+
+import json
+import os
+
+if "GITHUB_ENV" not in os.environ:
+    raise KeyError("Error: $GITHUB_ENV is undefined.")
+
+# File written by a previous workflow step
+with open("/tmp/built_images.json") as bij:
+  data = []
+  for build in json.load(bij):  # list of build data maps
+    stage = build.get("stage",False)
+    name = build.get("name",False)
+    sfx = build.get("sfx",False)
+    task = build.get("task",False)
+    if stage and name and sfx:
+        image_suffix = f'{stage[0]}{sfx}'
+        data.append(dict(stage=stage, name=name,
+            image_suffix=image_suffix, task=task))
+
+url='https://cirrus-ci.com/task'
+lines=[]
+data.sort(key=lambda item: str(item["stage"]+item["name"]))
+for item in data:
+  lines.append('|*{0}*|[{1}]({2})|`{3}`|\n'.format(item['stage'],
+    item['name'], '{0}/{1}'.format(url, item['task']),
+    item['image_suffix']))
+
+# This is the mechanism required to set an multi-line env. var.
+# value to be consumed by future workflow steps.
+with open(os.environ["GITHUB_ENV"], "a") as ghenv:
+  ghenv.write(("IMAGE_TABLE<<EOF\n"
+               "[Cirrus CI build](https://cirrus-ci.com/build/${{ steps.retro.outputs.bid }})"
+               " successful. [Found built image names and"
+               " IDs](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}):\n"
+               "\n"
+               "|*Stage*|**Image Name**|`IMAGE_SUFFIX`|\n"
+               "|---|---|---|\n"))
+  ghenv.writelines(lines)
+  ghenv.write("EOF\n\n")

--- a/.github/workflows/pr_image_id.yml
+++ b/.github/workflows/pr_image_id.yml
@@ -76,53 +76,31 @@ jobs:
                 printf "\n::set-output name=count::%s\n" "$dled"
 
             - if: steps.manifests.outputs.count > 0
-              name: Extract packer builder names and artifact IDs
+              name: Extract build details from manifest files
               env:
                 FLTR: >-
-                    {"name": .builds[].name,
-                     "id": .builds[].artifact_id | ltrimstr("us-east-1:"),
-                     "stage": .builds[].custom_data.STAGE} |
-                    select(.stage == "cache")
+                    {"stage": .builds[].custom_data.STAGE,
+                     "name": .builds[].name,
+                     "sfx": .builds[].custom_data.IMG_SFX,
+                     "task": .builds[].custom_data.TASK}
               run: |
                 find ./${{ steps.retro.outputs.bid }} \
                     -type f -name 'manifest.json' -print0 | \
-                xargs --null jq -e -c "$FLTR" |
-                    jq -e -s '.' > built_cache_images.json
+                xargs --null jq -e -c "$FLTR" | \
+                    jq -e -s '.' > /tmp/built_images.json
 
             - if: steps.manifests.outputs.count > 0
-              name: Debug built_cache_images.json contents
+              name: Debug built_images.json contents
               run: |
-                jq --color-output . built_cache_images.json
+                jq --color-output . /tmp/built_images.json
+
+            - if: steps.manifests.outputs.count > 0
+              uses: actions/checkout@v2
 
             - if: steps.manifests.outputs.count > 0
               id: body
               name: Format PR-comment body
-              shell: python
-              # Setting multi-line values of step outputs is problematic,
-              # setting a future (global) env. var. value is the only
-              # reasonable option.  This tricky bit of python sets the
-              # global $BUILT_CACHE_IMAGES env. var for subsequent workflow
-              # steps via the file referenced in $GITHUB_ENV.  The
-              # $BUILT_CACHE_IMAGES contents are the markdown to post as
-              # a PR comment.
-              run: |
-                import sys, os, json
-                l = []
-                with open("built_cache_images.json") as f:
-                  for b in json.load(f):  # list of builds
-                    if b.get("id") is not None:
-                      l.append(f'|**{b["name"]}**|`{b["id"]}`|\n')
-                l.sort(key=str.lower)
-                with open(os.environ["GITHUB_ENV"], "a") as e:
-                  e.write(("BUILT_CACHE_IMAGES<<EOF\n"
-                             "[Cirrus CI build](https://cirrus-ci.com/build/${{ steps.retro.outputs.bid }})"
-                             " successful. [Found built image names and"
-                             " IDs](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}):\n"
-                             "\n"
-                             "|Name|ID|\n"
-                             "|---|---|\n"))
-                  e.writelines(l)
-                  e.write("EOF\n")
+              run: .github/actions/bin/create_image_table.py
 
             - if: steps.manifests.outputs.count > 0
               name: Debug PR comment markdown
@@ -131,15 +109,15 @@ jobs:
               # The quoted-EOD prevents any shell interpretation.
               run: |
                 cat <<"EOD"
-                ${{ env.BUILT_CACHE_IMAGES }}
+                ${{ env.IMAGE_TABLE }}
                 EOD
 
             - if: steps.manifests.outputs.count > 0
               name: Post PR comment with image name/id table
-              uses: jungwinter/comment@v1
+              uses: jungwinter/comment@v1.1.0
               with:
                   issue_number: '${{ steps.retro.outputs.prn }}'
                   type: 'create'
                   token: '${{ secrets.GITHUB_TOKEN }}'
                   body: |
-                    ${{ env.BUILT_CACHE_IMAGES }}
+                    ${{ env.IMAGE_TABLE }}

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ if_ci_else = $(if $(findstring true,$(CI)),$(1),$(2))
 # VM images, and storage objects.
 export GAC_FILEPATH
 
+# When operating under Cirrus-CI, provide access to this for child processes
+export CIRRUS_TASK_ID
+
 # Ditto for AWS credentials (INI file) with access to create VMs and images.
 # ref: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where
 export AWS_SHARED_CREDENTIALS_FILE

--- a/base_images/cloud.yml
+++ b/base_images/cloud.yml
@@ -14,6 +14,9 @@ variables:  # Empty value means it must be passed in on command-line
     # Naming suffix for images to prevent clashes
     IMG_SFX:
 
+    # Allows providing handy cross-reference to the build log
+    CIRRUS_TASK_ID: "{{env `CIRRUS_TASK_ID`}}"
+
     # BIG-FAT-WARNING:  When updating the image names and/or URLs below,
     # ensure the distro version numbers contained in the `podman/*_release`
     # files exactly match.  These represent the container base-image tags
@@ -230,3 +233,4 @@ post-processors:
         custom_data:
             IMG_SFX: '{{ user `IMG_SFX` }}'
             STAGE: base
+            TASK: '{{user `CIRRUS_TASK_ID`}}'

--- a/cache_images/cloud.yml
+++ b/cache_images/cloud.yml
@@ -13,6 +13,8 @@ variables:  # Empty value means it must be passed in on command-line
     # Required path to service account credentials file
     GAC_FILEPATH: "{{env `GAC_FILEPATH`}}"
 
+    # Allows providing handy cross-reference to the build log
+    CIRRUS_TASK_ID: "{{env `CIRRUS_TASK_ID`}}"
 
 builders:
     - &gce_hosted_image
@@ -185,3 +187,4 @@ post-processors:
         custom_data:
             IMG_SFX: '{{ user `IMG_SFX` }}'
             STAGE: 'cache'
+            TASK: '{{user `CIRRUS_TASK_ID`}}'

--- a/image_builder/gce.yml
+++ b/image_builder/gce.yml
@@ -14,6 +14,9 @@ variables:
     # N/B: There are length/character limitations in GCE for image names
     IMG_SFX: '{{ timestamp }}'
 
+    # Allows providing handy cross-reference to the build log
+    CIRRUS_TASK_ID: "{{env `CIRRUS_TASK_ID`}}"
+
 
 builders:
     - name: 'image-builder'
@@ -56,3 +59,5 @@ post-processors:
         strip_path: true
         custom_data:
             IMG_SFX: '{{ user `IMG_SFX` }}'
+            STAGE: "base"
+            TASK: '{{user `CIRRUS_TASK_ID`}}'


### PR DESCRIPTION
Since this GHA workflow's previous update, support has been added to
Cirrus-CI such that downstream CI can reference EC2 images by
the same `$IMAGE_SUFFIX` value used in GCP.  Overhaul the image-table
posted to PRs by this workflow, such that it reflects this, and provides
a handy-dandy link directly to the build-log for each image.  Also,
sort the table rows by the stage + image name.

Signed-off-by: Chris Evich <cevich@redhat.com>