### PR TITLE
Lookup Fedora image & checksum URLs on demand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ define packer_build
 		FEDORA_ARM64_IMAGE_URL=$(call err_if_empty,FEDORA_ARM64_IMAGE_URL) \
 		FEDORA_ARM64_CSUM_URL=$(call err_if_empty,FEDORA_ARM64_CSUM_URL) \
 		PRIOR_FEDORA_IMAGE_URL=$(call err_if_empty,PRIOR_FEDORA_IMAGE_URL) \
-		PRIOR_FEDORA_CSUM_URL=$(call err_if_empty,_PRIOR_FEDORA_IMAGE_URL) \
+		PRIOR_FEDORA_CSUM_URL=$(call err_if_empty,PRIOR_FEDORA_CSUM_URL) \
 			$(PACKER_INSTALL_DIR)/packer build \
 			-force \
 			-var TEMPDIR="$(_TEMPDIR)" \
@@ -328,7 +328,7 @@ $(_TEMPDIR)/%.ami.json: $(_TEMPDIR)/%.ami.id $(_TEMPDIR)/%.ami.name
 		--resources "$$(<$(_TEMPDIR)/$*.ami.id)" \
 		--tags \
 			Key=Name,Value=$$(<$(_TEMPDIR)/$*.ami.name) \
-			Key=automation,Value=true
+			Key=automation,Value=false
 	$(AWS) --output table ec2 describe-images --image-ids "$$(<$(_TEMPDIR)/$*.ami.id)" \
 		| tee $@
 

--- a/get_fedora_url.sh
+++ b/get_fedora_url.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# This script is intended to be called by the Makefile, not by
+# humans.  This implies certain otherwise "odd" behaviors, such
+# as exiting with no std-output if there was an error.  It expects
+# to be called with three arguments:
+# 1. The type of url to retrieve, `image` or `checksum`.
+# 2. The architecture, `x86_64` or `aarch64`
+# 3. The Fedora release, 'rawhide' or a release number.
+
+set -eo pipefail
+
+URL_BASE="https://dl.fedoraproject.org/pub/fedora/linux"
+CURL="curl --location --silent --fail --show-error"
+
+url_type="$1"
+arch_name="$2"
+fed_rel="$3"
+
+die() { echo "ERROR: ${1:-No error message provided}" > /dev/stderr; exit 1; }
+
+msg() { echo "${1:-No error message provided}" > /dev/stderr; }
+
+usage_sfx="<image|checksum> <x86_64|aarch64> <release #>"
+
+[[ "$#" -eq 3 ]] || \
+    die "Expecting exactly 3 arguments: $usage_sfx"
+
+tmpfile=$(mktemp -p '' tmp.$(basename ${BASH_SOURCE[0]}).XXXX)
+trap "rm -f $tmpfile" EXIT
+
+stage_tree="development"
+if  [[ "$fed_rel" != "rawhide" ]] && \
+    $CURL "${URL_BASE}/releases/$fed_rel" &>/dev/null
+then
+    stage_tree="releases"
+fi
+
+cloud_download_url="${URL_BASE}/$stage_tree/$fed_rel/Cloud/$arch_name/images"
+dbg_msg_sfx="'$arch_name' arch Fedora '$fed_rel' release '$url_type' from '$cloud_download_url'"
+
+# Show usage again to help catch argument order / spelling mistakes.
+$CURL -o "$tmpfile" "$cloud_download_url" || \
+    die "Fetching download listing for $dbg_msg_sfx.
+Was argument form valid: $usage_sfx"
+
+targets=$(sed -ne 's/^.*href=\"\(fedora[^\"]\+\)\".*$/\1/ip' <$tmpfile)
+targets_oneline=$(tr -s '[:blank:]' ' '<<<"$targets")
+[[ -n "$targets" ]] || \
+    die "Did not find any fedora targets: $dbg_msg_sfx"
+
+# Sometimes "rawhide" is spelled "Rawhide"
+by_release=$(grep -iw "$fed_rel" <<<"$targets" || true)
+[[ -n "$by_release" ]] || \
+    die "Did not find target among '$targets_oneline)': $dbg_msg_sfx"
+
+by_arch=$(grep -iw "$arch_name" <<<"$by_release" || true)
+[[ -n "$by_arch" ]] || \
+    die "Did not find arch among $by_release"
+
+if [[ "$url_type" == "image" ]]; then
+    extension=qcow2
+elif [[ "$url_type" == "checksum" ]]; then
+    extension=CHECKSUM
+else
+    die "Unknown/unsupported url type: '$url_type'."
+fi
+
+# Support both '.CHECKSUM' and '-CHECKSUM' at the end
+filename=$(egrep -i -m 1 -- "$extension$" <<<"$by_arch" || true)
+[[ -n "$filename" ]] || \
+    die "No '$extension' targets among $by_arch"
+
+echo "$cloud_download_url/$filename"


### PR DESCRIPTION
Fixes: #190

Previously, maintainers were required to not only fill out the desired Fedora release numbers, but also manually look up six separate URLs and copy-paste their values.  This is a pain in the butt and error-prone. Add a script to perform the lookups and call the script for the required URLs only when required.  In other words, don't execute the script for `make help` or other targets that don't require the URLs.

How to test:
* From a VM with plenty of network bandwidth - Follow [the image import README](https://github.com/containers/automation_images/tree/main/import_images#readme)
* Some of the AWS operations remain less-than-reliable, see [the Failure responses section.](https://github.com/containers/automation_images/tree/main/import_images#failure-responses)
* For fun and profit, try `make import_images FEDORA_RELEASE=rawhide`