### PR TITLE
Publish the latest image-build table to a gist

### DIFF
--- a/.github/actions/bin/create_image_table.py
+++ b/.github/actions/bin/create_image_table.py
@@ -52,13 +52,17 @@ for item in data:
 
 # This is the mechanism required to set an multi-line env. var.
 # value to be consumed by future workflow steps.
-with open(os.environ["GITHUB_ENV"], "a") as ghenv:
-  ghenv.write(("IMAGE_TABLE<<EOF\n"
-              f"[Cirrus CI build](https://cirrus-ci.com/build/{cirrus_ci_build_id})"
-               " successful. [Found built image names and"
-              f' IDs](https://github.com/{os.environ["GITHUB_REPOSITORY"]}/actions/runs/{os.environ["GITHUB_RUN_ID"]}):\n'
-               "\n"
-               "|*Stage*|**Image Name**|`IMAGE_SUFFIX`|\n"
-               "|---|---|---|\n"))
-  ghenv.writelines(lines)
-  ghenv.write("EOF\n\n")
+with open(os.environ["GITHUB_ENV"], "a") as ghenv \
+     open('/tmp/built_images.md', "w") as mdfile:
+    header=( "IMAGE_TABLE<<EOF\n"
+            f"[Cirrus CI build](https://cirrus-ci.com/build/{cirrus_ci_build_id})"
+             " successful. [Found built image names and"
+            f' IDs](https://github.com/{os.environ["GITHUB_REPOSITORY"]}/actions/runs/{os.environ["GITHUB_RUN_ID"]}):\n'
+             "\n"
+             "|*Stage*|**Image Name**|`IMAGE_SUFFIX`|\n"
+             "|---|---|---|\n")
+    ghenv.write(header)
+    mdfile.write(header)
+    ghenv.writelines(lines)
+    mdfile.writelines(lines)
+    ghenv.write("EOF\n\n")

--- a/.github/workflows/pr_image_id.yml
+++ b/.github/workflows/pr_image_id.yml
@@ -15,6 +15,10 @@ jobs:
         # Do not execute for other github applications, only works with cirrus-ci
         if: github.event.check_suite.app.name == 'Cirrus CI'
         runs-on: ubuntu-latest
+        env:
+            # This is the last component of the gist URL
+            # i.e. https://gist.github.com/<user>/<id>
+            built_images_gist_id: f505b6fb78db279855862e035629f8aa
         steps:
             - name: Execute latest upstream cirrus-ci_retrospective
               uses: docker://quay.io/libpod/cirrus-ci_retrospective:latest
@@ -103,6 +107,12 @@ jobs:
               run: .github/actions/bin/create_image_table.py
 
             - if: steps.manifests.outputs.count > 0
+              name: Debug built_images.md contents
+              # Produced by create_image_table.py
+              run: cat /tmp/built_images.md
+
+            # jungwinter/comment cannot consume a file as comment input
+            - if: steps.manifests.outputs.count > 0
               name: Debug PR comment markdown
               # Use a here-document to display to avoid any
               # problems with passing special-characters into echo
@@ -121,3 +131,23 @@ jobs:
                   token: '${{ secrets.GITHUB_TOKEN }}'
                   body: |
                     ${{ env.IMAGE_TABLE }}
+
+            # Ref: https://github.com/marketplace/actions/deploy-to-gist
+            - if: steps.manifests.outputs.count > 0
+              name: Publish image name/id MD table to gist
+              uses: exuanbo/actions-deploy-gist@v1.1.4
+              with:
+                  token: ${{ secrets.IMG_GIST_TOKEN }}
+                  gist_id: ${{ env.built_images_gist_id }}
+                  gist_file_name: images.md
+                  file_path: /tmp/built_images.md
+                  file_type: text
+            - if: steps.manifests.outputs.count > 0
+              name: Publish image name/id JSON table to gist
+              uses: exuanbo/actions-deploy-gist@v1.1.4
+              with:
+                  token: ${{ secrets.IMG_GIST_TOKEN }}
+                  gist_id: ${{ secrets.IMG_GIST_TOKEN }}
+                  gist_file_name: images.json
+                  file_path: /tmp/built_images.json
+                  file_type: text


### PR DESCRIPTION
Support future tooling and humans in locating the most recently built VM images.  Publish both JSON and MD formated files to a GitHub Gist.

Signed-off-by: Chris Evich <cevich@redhat.com>