### PR TITLE
[CI:DOCS] Use paths relative to CWD

### DIFF
--- a/.github/actions/bin/create_image_table.py
+++ b/.github/actions/bin/create_image_table.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-"""Parse /tmp/built_images.json into MD table in $IMAGE_TABLE."""
+"""Parse ./built_images.json into MD table in $IMAGE_TABLE."""
 
 # Note: This script is exclusively intended to be used by the
 # pr_image_id.yml github-actions workflow.  Any use outside that
@@ -28,7 +28,7 @@ if "GITHUB_ENV" not in os.environ:
 cirrus_ci_build_id = None
 
 # File written by a previous workflow step
-with open("/tmp/built_images.json") as bij:
+with open("./built_images.json") as bij:
   data = []
   for build in json.load(bij):  # list of build data maps
     stage = build.get("stage", False)
@@ -53,7 +53,7 @@ for item in data:
 # This is the mechanism required to set an multi-line env. var.
 # value to be consumed by future workflow steps.
 with open(os.environ["GITHUB_ENV"], "a") as ghenv, \
-     open('/tmp/built_images.md', "w") as mdfile:
+     open('./built_images.md', "w") as mdfile:
     header = ("IMAGE_TABLE<<EOF\n"
              f"[Cirrus CI build](https://cirrus-ci.com/build/{cirrus_ci_build_id})"
               " successful. [Found built image names and"

--- a/.github/workflows/pr_image_id.yml
+++ b/.github/workflows/pr_image_id.yml
@@ -91,12 +91,12 @@ jobs:
                 find ./${{ steps.retro.outputs.bid }} \
                     -type f -name 'manifest.json' -print0 | \
                 xargs --null jq -e -c "$FLTR" | \
-                    jq -e -s '.' > /tmp/built_images.json
+                    jq -e -s '.' > ./built_images.json
 
             - if: steps.manifests.outputs.count > 0
               name: Debug built_images.json contents
               run: |
-                jq --color-output . /tmp/built_images.json
+                jq --color-output . ./built_images.json
 
             - if: steps.manifests.outputs.count > 0
               uses: actions/checkout@v2
@@ -109,7 +109,7 @@ jobs:
             - if: steps.manifests.outputs.count > 0
               name: Debug built_images.md contents
               # Produced by create_image_table.py
-              run: cat /tmp/built_images.md
+              run: cat ./built_images.md
 
             # jungwinter/comment cannot consume a file as comment input
             - if: steps.manifests.outputs.count > 0
@@ -140,7 +140,7 @@ jobs:
                   token: ${{ secrets.IMG_GIST_TOKEN }}
                   gist_id: ${{ env.built_images_gist_id }}
                   gist_file_name: images.md
-                  file_path: /tmp/built_images.md
+                  file_path: ./built_images.md
                   file_type: text
             - if: steps.manifests.outputs.count > 0
               name: Publish image name/id JSON table to gist
@@ -149,5 +149,5 @@ jobs:
                   token: ${{ secrets.IMG_GIST_TOKEN }}
                   gist_id: ${{ secrets.IMG_GIST_TOKEN }}
                   gist_file_name: images.json
-                  file_path: /tmp/built_images.json
+                  file_path: ./built_images.json
                   file_type: text


### PR DESCRIPTION
Some github actions do unexpected mangling of input paths.  Adjust all file i/o to be relative to CWD which seems to always be available regardless of context.

Signed-off-by: Chris Evich <cevich@redhat.com>