### PR TITLE
[CI:DOCS] Fix GITHUB_WORKSPACE context

### DIFF
--- a/.github/workflows/pr_image_id.yml
+++ b/.github/workflows/pr_image_id.yml
@@ -73,6 +73,9 @@ jobs:
                 $PODMAN $PR_CCIA "${ARGS[@]}" || $PODMAN $UP_CCIA "${ARGS[@]}"
 
             - if: steps.retro.outputs.is_pr == 'true'
+              uses: actions/checkout@v2
+
+            - if: steps.retro.outputs.is_pr == 'true'
               name: Count the number of manifest.json files downloaded
               id: manifests
               run: |
@@ -97,9 +100,6 @@ jobs:
               name: Debug built_images.json contents
               run: |
                 jq --color-output . $GITHUB_WORKSPACE/built_images.json
-
-            - if: steps.manifests.outputs.count > 0
-              uses: actions/checkout@v2
 
             - if: steps.manifests.outputs.count > 0
               id: body


### PR DESCRIPTION
The location of this directory changes based on having run the checkout action or not.  Since it ran later in the `pr_image_id` workflow, the python script was not able to find the `built_images.json` file.  Fix this by checking out the repository earlier in the pipeline.

Signed-off-by: Chris Evich <cevich@redhat.com>