### PR TITLE
add dnsmasq to netavark image

### DIFF
--- a/cache_images/fedora-netavark_packaging.sh
+++ b/cache_images/fedora-netavark_packaging.sh
@@ -27,6 +27,7 @@ INSTALL_PACKAGES=(\
     bzip2
     curl
     dbus-daemon
+    dnsmasq
     findutils
     firewalld
     gcc
@@ -51,6 +52,7 @@ INSTALL_PACKAGES=(\
     openssl-devel
     podman
     policycoreutils
+    protobuf-devel
     rsync
     sed
     slirp4netns


### PR DESCRIPTION
The netavark-dhcp-proxy test suite needs the dnsmasq package to serve as a DHCP server.

Signed-off-by: Brent Baude <bbaude@redhat.com>