### PR TITLE
[CI:DOCS] Fix gist content + Missing json gist

### DIFF
--- a/.github/actions/bin/create_image_table.py
+++ b/.github/actions/bin/create_image_table.py
@@ -26,7 +26,7 @@ if "GITHUB_ENV" not in os.environ:
     raise KeyError("Error: $GITHUB_ENV is undefined.")
 
 cirrus_ci_build_id = None
-github_workspace = os.environ.get("GITHUB_WORKSPACE", "/tmp")
+github_workspace = os.environ.get("GITHUB_WORKSPACE", ".")
 
 # File written by a previous workflow step
 with open(f"{github_workspace}/built_images.json") as bij:
@@ -55,14 +55,16 @@ for item in data:
 # value to be consumed by future workflow steps.
 with open(os.environ["GITHUB_ENV"], "a") as ghenv, \
      open(f'{github_workspace}/built_images.md', "w") as mdfile:
-    header = ("IMAGE_TABLE<<EOF\n"
-             f"[Cirrus CI build](https://cirrus-ci.com/build/{cirrus_ci_build_id})"
-              " successful. [Found built image names and"
-             f' IDs](https://github.com/{os.environ["GITHUB_REPOSITORY"]}'
-             f'/actions/runs/{os.environ["GITHUB_RUN_ID"]}):\n'
-              "\n"
-              "|*Stage*|**Image Name**|`IMAGE_SUFFIX`|\n"
-              "|---|---|---|\n")
+
+    env_header = ("IMAGE_TABLE<<EOF\n")
+    header = (f"[Cirrus CI build](https://cirrus-ci.com/build/{cirrus_ci_build_id})"
+               " successful. [Found built image names and"
+              f' IDs](https://github.com/{os.environ["GITHUB_REPOSITORY"]}'
+              f'/actions/runs/{os.environ["GITHUB_RUN_ID"]}):\n'
+               "\n"
+               "|*Stage*|**Image Name**|`IMAGE_SUFFIX`|\n"
+               "|---|---|---|\n")
+    ghenv.write(env_header)
     ghenv.write(header)
     mdfile.write(header)
     ghenv.writelines(lines)

--- a/.github/workflows/pr_image_id.yml
+++ b/.github/workflows/pr_image_id.yml
@@ -139,7 +139,7 @@ jobs:
               with:
                   token: ${{ secrets.IMG_GIST_TOKEN }}
                   gist_id: ${{ env.built_images_gist_id }}
-                  file_path: ${{ env.GITHUB_WORKSPACE }}/built_images.md
+                  file_path: built_images.md
                   file_type: text
             - if: steps.manifests.outputs.count > 0
               name: Publish image name/id JSON table to gist
@@ -147,5 +147,5 @@ jobs:
               with:
                   token: ${{ secrets.IMG_GIST_TOKEN }}
                   gist_id: ${{ secrets.IMG_GIST_TOKEN }}
-                  file_path: ${{ env.GITHUB_WORKSPACE }}/built_images.json
+                  file_path: built_images.json
                   file_type: text


### PR DESCRIPTION
The md gist contains the "IMAGE_TABLE" here-document line, remove that. Also attempt to fix failure to post the JSON gist.  When it ran previously, the action reported the (unhelpful) error: "not found"

https://github.com/containers/automation_images/actions/runs/3100655221/jobs/5021168174#step:17:35

Signed-off-by: Chris Evich <cevich@redhat.com>