### PR TITLE
[CI:DOCS] Fix lack of validation on comparison

### DIFF
--- a/.github/workflows/pr_image_id.yml
+++ b/.github/workflows/pr_image_id.yml
@@ -57,7 +57,8 @@ jobs:
                       printf "\n::set-output name=is_pr::%s\n" "false"
                   fi
 
-            - uses: actions/checkout@v2
+            - if: steps.retro.outputs.is_pr == 'true'
+              uses: actions/checkout@v2
 
             - if: steps.retro.outputs.is_pr == 'true'
               name: Retrieve and process any manifest artifacts
@@ -79,7 +80,11 @@ jobs:
               id: manifests
               run: |
                 dled=$(find $GITHUB_WORKSPACE -type f -name 'manifest.json' | wc -l)
-                printf "\n::set-output name=count::%s\n" "$dled"
+                if [[ "$dled" =~ ^[0-9]+$ ]]; then
+                    printf "\n::set-output name=count::%s\n" "$dled"
+                else
+                    printf "\n::set-output name=count::0\n"
+                fi
 
             - if: steps.manifests.outputs.count > 0
               name: Extract build details from manifest files


### PR DESCRIPTION
Apparently github-action workflow will absolutely treat the conditional 'if '' > 0' as "true".  Fix this by validating the count is a number before setting it.

Signed-off-by: Chris Evich <cevich@redhat.com>