### PR TITLE
[CI:TOOLING] Build updated get_ci_vm container image

### DIFF
--- a/get_ci_vm/good_repo_test/.cirrus.yml
+++ b/get_ci_vm/good_repo_test/.cirrus.yml
@@ -11,3 +11,7 @@ google_test_task:
 container_test_task:
     container:
         image: something
+
+windows_container_test_task:
+    windows_container:
+        image: cirrusci/windowsservercore:2019

--- a/lib.sh
+++ b/lib.sh
@@ -19,7 +19,7 @@ OS_REL_VER="$OS_RELEASE_ID-$OS_RELEASE_VER"
 # This location is checked by automation in other repos, please do not change.
 PACKAGE_DOWNLOAD_DIR=/var/cache/download
 
-INSTALL_AUTOMATION_VERSION="4.1.1"
+INSTALL_AUTOMATION_VERSION="4.1.2"
 
 PUSH_LATEST="${PUSH_LATEST:-0}"
 


### PR DESCRIPTION
Includes support for parsing 'windows_container' tasks.

Signed-off-by: Chris Evich <cevich@redhat.com>