### PR TITLE
Revert update to F36/37 images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ if_ci_else = $(if $(findstring true,$(CI)),$(1),$(2))
 
 export CENTOS_STREAM_RELEASE = 8
 
-export FEDORA_RELEASE = 37
-export PRIOR_FEDORA_RELEASE = 36
+export FEDORA_RELEASE = 36
+export PRIOR_FEDORA_RELEASE = 35
 
 # See import_images/README.md
-export FEDORA_IMPORT_IMG_SFX = 1662988741
+export FEDORA_IMPORT_IMG_SFX = 1663877149
 
 export UBUNTU_RELEASE = 22.04
 export UBUNTU_BASE_FAMILY = ubuntu-2204-lts


### PR DESCRIPTION
The transition has hit some operational and technical hiccups and delays. This is blocking others from doing needed updates on the old images. Fix this for everyone by reverting back to F35/36 on main.  Work on F37 will continue independently in:

https://github.com/containers/automation_images/pull/195

Signed-off-by: Chris Evich <cevich@redhat.com>