### PR TITLE
[CI:TOOLING] Fix GCP orphan VMs detection

### DIFF
--- a/orphanvms/_gce
+++ b/orphanvms/_gce
@@ -17,10 +17,11 @@ FILTER="status!=TERMINATED AND lastStartTimestamp<$THRESHOLD AND labels.list(sho
 # only non-matching output.  Unfortunately, if if there is no output for some
 # reason, this will cause grep to fail.  Ignore this, since the next gcloud
 # command to follow will complain loudly if the credentials aren't sufficient.
+dbg "Initializing gcloud"
 gcloud_init |& grep -Eiv '^Activated service account credentials for:' || true
 
 # shellcheck disable=SC2154,SC2153
-for gcpproject in $gcpprojectS; do
+for gcpproject in $GCPPROJECTS; do
     dbg "Examining $gcpproject"
     OUTPUT=$(mktemp -p '' orphanvms_${gcpproject}_XXXXX)
     echo "Orphaned $gcpproject VMs:" > $OUTPUT

--- a/orphanvms/entrypoint.sh
+++ b/orphanvms/entrypoint.sh
@@ -37,5 +37,6 @@ dbg() {
 
 # shellcheck source=orphanvms/gce
 . /usr/local/bin/_gce
+
 # shellcheck source=orphanvms/ec2
 . /usr/local/bin/_ec2


### PR DESCRIPTION
Manual ovservation shows lost VMs from Packer which should have been picked up by this check.

Signed-off-by: Chris Evich <cevich@redhat.com>