### PR TITLE
[CI:TOOLING] Fix orphanvms listing duplicate orphans

### DIFF
--- a/orphanvms/_gce
+++ b/orphanvms/_gce
@@ -27,7 +27,7 @@ for gcpproject in $GCPPROJECTS; do
     echo "Orphaned $gcpproject VMs:" > $OUTPUT
 
     # Ref: https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#deprecating_an_image
-    $GCLOUD compute instances list --format="$FORMAT" --filter="$FILTER" | \
+    $GCLOUD compute instances list --project=$gcpproject --format="$FORMAT" --filter="$FILTER" | \
         while read name lastStartTimestamp labels
         do
             dbg "VM $name started $lastStartTimestamp labeled $labels"


### PR DESCRIPTION
The gcloud command run for each project was not restricting it's search by project name.  This resulted in iterating multiple times over the same set of orphan search results.  Fix this by adding telling gcloud to only look in a single, specific project.

Signed-off-by: Chris Evich <cevich@redhat.com>