### PR TITLE
Temp. remove podman package from Ubuntu Images

### DIFF
--- a/cache_images/ubuntu_packaging.sh
+++ b/cache_images/ubuntu_packaging.sh
@@ -78,6 +78,10 @@ setup_obs tools criu
 
 # N/B: DO NOT install the bats package on Ubuntu VMs, it's broken.
 # ref: (still open) https://bugs.launchpad.net/ubuntu/+source/bats/+bug/1882542
+#
+# TODO: ADD podman BACK INTO THIS LIST.  IT'S NEEDED BY CI TESTS IN
+# BUILDAH AND LIKELY ELSEWHERE TOO.
+#
 INSTALL_PACKAGES=(\
     apache2-utils
     apparmor
@@ -141,7 +145,6 @@ INSTALL_PACKAGES=(\
     openssl
     parallel
     pkg-config
-    podman
     podman-plugins
     protobuf-c-compiler
     protobuf-compiler


### PR DESCRIPTION
A problem with broken dependency on netavark causes image build failure.
Since Podman CI doesn't need a podman package, simply remove it
temporarily.  Then sprinkle some hope and prayer around, that nobody gets
the "smart" idea to try and use this image anywhere outside of podman
CI.