### PR TITLE
Fix build-push auto-update test

### DIFF
--- a/build-push/.install.sh
+++ b/build-push/.install.sh
@@ -16,6 +16,7 @@ then
 fi
 
 source /etc/automation_environment
+source "$AUTOMATION_LIB_PATH/common_lib.sh"
 
 #shellcheck disable=SC2154
 cd $(dirname "$SCRIPT_FILEPATH") || exit 1

--- a/build-push/test.sh
+++ b/build-push/test.sh
@@ -178,12 +178,17 @@ source "$AUTOMATION_LIB_PATH/common_lib.sh"
 source "$AUTOMATION_LIB_PATH/autoupdate.sh"
 EOF
 chmod +x main.sh
+# Back to where we were
+cd -
 
 # Expect the real main.sh to bark one of two error messages
 # and exit non-zero.
 EXP_RX1="Must.be.called.with.at.least.two.arguments"
 EXP_RX2="does.not.appear.to.be.the.root.of.a.git.repo"
-if output=$(env BUILDPUSHAUTOUPDATED=0 ./main.sh 2>&1); then
+if output=$(env --ignore-environment \
+            BUILDPUSHAUTOUPDATED=0 \
+            AUTOMATION_LIB_PATH=$AUTOMATION_LIB_PATH \
+            $SRC_TMP/main.sh 2>&1); then
     die "Fail.  Expected main.sh to exit non-zero"
 else
     if [[ "$output" =~ $EXP_RX1 ]] || [[ "$output" =~ $EXP_RX2 ]]; then


### PR DESCRIPTION
This test has been failing recently with the error:

```
************************************************
realpath: ./build-push/test.sh: No such file or directory
realpath: missing operand
Try 'realpath --help' for more information.
ERROR: Fail.  Expecting match to
'Must.be.called.with.exactly.two.arguments' or
'does.not.appear.to.be.the.root.of.a.git.repo', got:
Auto-updating build-push operational scripts...
Obtaining latest version...
Installing...
/tmp/tmp-build-push-test-LpQS
Re-executing main.sh ...
```

Attempt to fix this by running the mock `main.sh` script using it's full path and a completely clean shell environment.  Also, ensure install script fully imports the automation common lib, and not just the location & path variables.

Signed-off-by: Chris Evich <cevich@redhat.com>