### PR TITLE
[CI:DOCS] Drop LFS metadata which conflicts with checked-in file

### DIFF
--- a/get_ci_vm/good_repo_test/.gitattributes
+++ b/get_ci_vm/good_repo_test/.gitattributes
@@ -1,1 +1,0 @@
-dot_git.tar.gz filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Drop LFS metadata which is inconsistent with the existing fully checked in file.

This fixes a problem where git usage on a system with git lfs fully installed will receive errors on clone, and the repo will be stuck in a permanent dirty state:

```
Cloning into 'automation_images'...
remote: Enumerating objects: 1919, done.
remote: Counting objects: 100% (267/267), done.
remote: Compressing objects: 100% (109/109), done.
remote: Total 1919 (delta 165), reused 239 (delta 144), pack-reused 1652
Receiving objects: 100% (1919/1919), 743.40 KiB | 3.18 MiB/s, done.
Resolving deltas: 100% (1322/1322), done.
Encountered 1 file that should have been a pointer, but wasn't:
	get_ci_vm/good_repo_test/dot_git.tar.gz

$ git status
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   get_ci_vm/good_repo_test/dot_git.tar.gz


$ git reset --hard HEAD
HEAD is now at 0385c4a Merge pull request #215 from cevich/enhanced_build_push_tests
Encountered 1 file that should have been a pointer, but wasn't:
	get_ci_vm/good_repo_test/dot_git.tar.gz

$ git status
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   get_ci_vm/good_repo_test/dot_git.tar.gz

```
