### PR TITLE
Introduce Windows VM AMI with WSL enabled

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,6 +34,7 @@ validate_task:
         - "make image_builder/gce.json"
         - "make base_images/cloud.json"
         - "make cache_images/cloud.json"
+        - "make win_images/win-server-wsl.json"
 
 
 image_builder_task:
@@ -230,6 +231,32 @@ cache_images_task:
     script: "ci/make.sh cache_images"
     manifest_artifacts:
         path: cache_images/manifest.json
+        type: application/json
+
+
+# Builds Windows server VMs for CI
+# Currently this produces a single Win 2022 Server Base image with WSL enabled
+win_images_task:
+    name: "Build VM Win-images"
+    alias: "win_images"
+    only_if: *is_pr
+    skip: *ci_docs_tooling
+    depends_on:
+        - 'validate'
+    # Packer needs time to clean up partially created VM images
+    auto_cancellation: $CI != "true"
+    stateful: true
+    timeout_in: 45m
+    # Packer WinRM communicator is not reliable on container tasks
+    gce_instance:
+        <<: *ibi_vm
+    env:
+      PACKER_BUILDS: "win-server-wsl"
+      GAC_JSON: *gac_json
+      AWS_INI: *aws_ini
+    script: "ci/make.sh win_images"
+    manifest_artifacts:
+        path: win_images/manifest.json
         type: application/json
 
 
@@ -461,6 +488,7 @@ success_task:
         - tooling_images
         - base_images
         - cache_images
+        - win_images
         - test_imgts
         - imgts
         - test_imgobsolete

--- a/Makefile
+++ b/Makefile
@@ -358,6 +358,12 @@ cache_images: cache_images/manifest.json ## Create, prepare, and import top-leve
 cache_images/manifest.json: cache_images/cloud.json $(wildcard cache_images/*.sh) $(PACKER_INSTALL_DIR)/packer
 	$(call packer_build,cache_images/cloud.json)
 
+.PHONY: win_images
+# This needs to run in a virt/nested-virt capable environment
+win_images: win_images/manifest.json
+win_images/manifest.json: win_images/win-server-wsl.json $(wildcard win_images/*.ps1) $(PACKER_INSTALL_DIR)/packer
+	$(call packer_build,win_images/win-server-wsl.json)
+
 .PHONY: fedora_podman
 fedora_podman:  ## Build Fedora podman development container
 	$(call build_podman_container,$@,$(FEDORA_RELEASE))

--- a/win_images/bootstrap.ps1
+++ b/win_images/bootstrap.ps1
@@ -1,0 +1,22 @@
+<powershell>
+# Allow powershell scripts to execute from fs
+Set-ExecutionPolicy Unrestricted -Scope LocalMachine -Force -ErrorAction Ignore
+$ErrorActionPreference = "stop"
+
+# Remove any existing WinRM HTTP listener
+Remove-Item -Path WSMan:\Localhost\listener\listener* -Recurse
+
+# Create a self-signed certificate for https
+$Cert = New-SelfSignedCertificate -CertstoreLocation Cert:\LocalMachine\My -DnsName "packer"
+
+# Configure WinRM over https to allow packer to manage
+cmd.exe /c winrm set "winrm/config" '@{MaxTimeoutms="1800000"}'
+cmd.exe /c winrm set "winrm/config/service/auth" '@{Basic="true"}'
+cmd.exe /c winrm set "winrm/config/client/auth" '@{Basic="true"}'
+cmd.exe /c winrm create "winrm/config/listener?Address=*+Transport=HTTPS" "@{Port=`"5986`";Hostname=`"packer`";CertificateThumbprint=`"$($Cert.Thumbprint)`"}"
+cmd.exe /c netsh advfirewall firewall set rule group="remote administration" new enable=yes
+cmd.exe /c netsh firewall add portopening TCP 5986 "Port 5986"
+# Start and Enable WinRM after restarts (required as part of provisioning process)
+cmd.exe /c sc config winrm start= auto
+cmd.exe /c net start winrm
+</powershell>

--- a/win_images/win-server-wsl.yml
+++ b/win_images/win-server-wsl.yml
@@ -1,0 +1,76 @@
+variables:
+  # Naming suffix for images to prevent clashes
+  IMG_SFX:
+
+  # Allows providing handy cross-reference to the build log
+  CIRRUS_TASK_ID: "{{env `CIRRUS_TASK_ID`}}"
+
+
+builders:
+  - type: amazon-ebs
+    name: win-server-wsl
+    source_ami_filter:
+      filters:
+        name: &win_release "Windows_Server-2022-English-Full-Base*"
+        root-device-type: ebs
+        virtualization-type: hvm
+      most_recent: true
+      owners:
+        - amazon
+    # While this image should run on metal, we can build it on smaller/cheaper systems 
+    instance_type: t3.large
+    force_deregister: true  # Remove AMI with same name if exists
+    force_delete_snapshot: true  # Also remove snapshots of force-removed AMI
+    # Note that we do not set shutdown_behavior to terminate, as a clean shutdown is required
+    # for windows provisioning to complete successfully.
+    communicator: winrm
+    winrm_username: Administrator # AWS provisions Administrator, unlike GCE 
+    winrm_insecure: true
+    winrm_use_ssl: true
+    winrm_timeout: 25m
+    # Script that runs on server start, needed to prep and enable winrm
+    user_data_file: '{{template_dir}}/bootstrap.ps1' 
+    # Required for network access, must be the 'default' group used by Cirrus-CI
+    security_group_id: "sg-042c75677872ef81c"
+    ami_name: &ami_name '{{build_name}}-c{{user `IMG_SFX`}}'
+    ami_description: 'Built in https://cirrus-ci.com/task/{{user `CIRRUS_TASK_ID`}}'
+
+    # These are critical and used by security-polciy to enforce instance launch limits.
+    tags: &awstags
+        # EC2 expects "Name" to be capitalized
+        Name: *ami_name
+        src: '{{.SourceAMI}}'
+        automation: 'true'
+        release: *win_release
+    run_tags: *awstags
+    run_volume_tags: *awstags
+    snapshot_tags: *awstags
+    # This is necessary for security - The CI service accounts are not permitted
+    # to use AMI's from any other account, including public ones.
+    ami_users:
+      - &accountid '449134212816'
+
+
+provisioners:
+  - type: powershell
+    script: '{{template_dir}}/win_packaging.ps1'
+  - type: windows-restart
+  - type: powershell
+    inline:
+      # Disable WinRM as a security precuation (cirrus launches an agent from user-data, so we don't need it)
+      - Set-Service winrm -StartupType Disabled
+      # NOTE: For now, we do not run sysprep, since initialization with reboots are exceptionally slow on metal nodes, which these
+      # target to run. This will lead to a duplicate machine id, which is not ideal, but allows instances to start instantly. 
+      # So, instead of sysprep, trigger a reset so that the admin password reset, and activation rerun on boot
+      - '& ''C:/Program Files/Amazon/EC2Launch/ec2launch'' reset --block'
+
+
+post-processors:
+  - type: 'manifest'
+    output: '{{template_dir}}/manifest.json'  # Collected by Cirrus-CI
+    strip_path: true
+    custom_data:
+      IMG_SFX: '{{ user `IMG_SFX` }}'
+      STAGE: cache
+      TASK: '{{user `CIRRUS_TASK_ID`}}'
+

--- a/win_images/win_packaging.ps1
+++ b/win_images/win_packaging.ps1
@@ -1,0 +1,35 @@
+function CheckExit {
+  param(
+    [parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $codes = @(0)
+  )
+  if ($LASTEXITCODE -eq $null) {
+    return
+  }
+
+  foreach ($code in $codes) {
+    if ($LASTEXITCODE -eq $code) {
+      return
+    }
+  }
+
+  Exit $LASTEXITCODE
+}
+
+
+# Disables runtime process virus scanning, which is not necessary
+Set-MpPreference -DisableRealtimeMonitoring 1
+$ErrorActionPreference = "stop"
+
+Set-ExecutionPolicy Bypass -Scope Process -Force
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+# Install Git, BZ2 archive support, Go, and the MingW (GCC for Win) compiler for CGO support
+choco install -y git mingw archiver; CheckExit
+choco install golang --version 1.19.2 -y; CheckExit
+
+# Install WSL, and capture text output which is not normally visible
+$x = wsl --install; CheckExit 0 1 # wsl returns 1 on reboot required
+Write-Output $x
+Exit 0


### PR DESCRIPTION
This PR introduces the build of a Windows 2022 Server AMI image with WSL enabled for CI testing.

While this image is generically usable, it's primary purpose is to enable Podman CI to verify Windows functionality, which relies on an environment supporting WSL. Since WSL requires the use of virtualization, the image must be run on bare metal nodes. However, the image itself is built on lower-cost t3 instances since virt is only necessary to *run* WSL (installing does not require it).

While the intended target for Podman on Windows is Windows 10 and Windows 11 Desktop environments, AWS only supports the usage and licensing of Server builds. Since Windows Server 2022 and Windows 10 are derived from the same common baseline, 2022 is sufficient for testing (earlier versions (e.g., 2019) are not.

To isolate the windows building functionality, this PR introduces a new win_images Makefile target, called by a new win_images task, and a windows specific packer template and support scripts. Currently, this only builds a single image, but it could be modified in the future to use a matrix similar to base_images (it currently reuses ci/make.sh). As with other image builds, windows images can be disabled using a "no_win_server_wsl" tag.

Since Podman currently only supports x86_64 (win support of ARM is very limited at this stage), there is only a single architecture required.





