### PR TITLE
[CI:DOCS] Update github actions set-output usage + Ensure CNI testing in Fedora N-1 CI VM Images

### DIFF
--- a/.github/workflows/orphan_vms.yml
+++ b/.github/workflows/orphan_vms.yml
@@ -62,7 +62,11 @@ jobs:
                 count=$(egrep -x '\* VM .+' /tmp/orphanvms_output.txt | wc -l)
                 # Assist with debugging job (step-outputs are otherwise hidden)
                 printf "Orphan VMs count:%d\n" $count
-                printf "::set-output name=count::%d\n" $count
+                if [[ "$count" =~ ^[0-9]+$ ]]; then
+                    printf "count=%d\n" $count >> $GITHUB_OUTPUT
+                else
+                    printf "count=0\n" >> $GITHUB_OUTPUT
+                fi
 
             - if: steps.orphans.outputs.count > 0
               shell: bash

--- a/.github/workflows/pr_image_id.yml
+++ b/.github/workflows/pr_image_id.yml
@@ -48,13 +48,13 @@ jobs:
                      [[ $prn -gt 0 ]] && \
                      [[ "$status" == "COMPLETED" ]]
                   then
-                      printf "\n::set-output name=prn::%s\n" "$prn"
-                      printf "\n::set-output name=bid::%s\n" "$bid"
-                      printf "\n::set-output name=is_pr::%s\n" "true"
+                      printf "prn=%s\n" "$prn" >> $GITHUB_OUTPUT
+                      printf "bid=%s\n" "$bid" >> $GITHUB_OUTPUT
+                      printf "is_pr=%s\n" "true" >> $GITHUB_OUTPUT
                   else
-                      printf "\n::set-output name=prn::%s\n" "0"
-                      printf "\n::set-output name=bid::%s\n" "0"
-                      printf "\n::set-output name=is_pr::%s\n" "false"
+                      printf "prn=%s\n" "0" >> $GITHUB_OUTPUT
+                      printf "bid=%s\n" "0" >> $GITHUB_OUTPUT
+                      printf "is_pr=%s\n" "false" >> $GITHUB_OUTPUT
                   fi
 
             - if: steps.retro.outputs.is_pr == 'true'
@@ -83,9 +83,9 @@ jobs:
               run: |
                 dled=$(find $GITHUB_WORKSPACE -type f -name 'manifest.json' -not -path '*fake_manifests/*/manifest.json' | wc -l)
                 if [[ "$dled" =~ ^[0-9]+$ ]]; then
-                    printf "\n::set-output name=count::%s\n" "$dled"
+                    printf "count=%s\n" "$dled" >> $GITHUB_OUTPUT
                 else
-                    printf "\n::set-output name=count::0\n"
+                    printf "count=0\n" >> $GITHUB_OUTPUT
                 fi
 
             - if: steps.manifests.outputs.count > 0

--- a/cache_images/fedora_packaging.sh
+++ b/cache_images/fedora_packaging.sh
@@ -156,9 +156,9 @@ INSTALL_PACKAGES=(\
     zstd
 )
 
-# test with CNI in F35 and lower
+# Test with CNI in Fedora N-1
 EXARG=""
-if [[ "$OS_RELEASE_VER" -le 35 ]]; then
+if [[ "$PACKER_BUILD_NAME" =~ prior ]]; then
     EXARG="--exclude=netavark --exclude=aardvark-dns"
 fi
 


### PR DESCRIPTION
Setting outputs this way is deprecated.  Ref:
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

Other commit is minor, it just removes a hard-coded version number.