### PR TITLE
[CI:DOCS] Minor: Remove GCP from e-mail text

### DIFF
--- a/.github/workflows/orphan_vms.yml
+++ b/.github/workflows/orphan_vms.yml
@@ -58,7 +58,7 @@ jobs:
               run: |
                 set -eo pipefail
                 (
-                echo "Detected ${{ steps.orphans.outputs.count }} Orphan GCP VM(s):"
+                echo "Detected ${{ steps.orphans.outputs.count }} Orphan VM(s):"
                 echo ""
                 cat /tmp/output.txt
                 echo ""


### PR DESCRIPTION
This e-mail now reports on both GCP and AWS VMs.

Signed-off-by: Chris Evich <cevich@redhat.com>