### PR TITLE
[skip-ci] Normalize cirrus-cron GHA fail-mail

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -6,7 +6,7 @@ on:
     # N/B: This should correspond to a period slightly after
     # the last job finishes running.  See job defs. at:
     # https://cirrus-ci.com/settings/repository/6680102350094336
-    - cron:  '59 23 * * 1-5'
+    - cron:  '03 03 * * 1-5'
   # Debug: Allow triggering job manually in github-actions WebUI
   workflow_dispatch: {}
 


### PR DESCRIPTION
Across all other repos that use cirrus-cron jobs and report failures, the later occurs at 03:03 UTC.  Normalize the schedule of the same job in this repo to be consistent with all the others.

Signed-off-by: Chris Evich <cevich@redhat.com>