### PR TITLE
Make AWS AMI's accessible by the public

### DIFF
--- a/base_images/cloud.yml
+++ b/base_images/cloud.yml
@@ -110,9 +110,9 @@ builders:
       type: 'amazon-ebs'
       source_ami_filter:  # Will fail if >1 or no AMI found
         owners:
-            # Docs are wrong, specifying the Account ID required to make AMIs private.
-            # The Account ID is hard-coded here out of expediency, since passing in
-            # more packer args from the command-line (in Makefile) is non-trivial.
+            # Docs are wrong, specifying the Account ID required to search only for
+            # our own imported AMIs. The Account ID is hard-coded here out of
+            # expediency.
             - &accountid '449134212816'
         # It's necessary to 'search' for the base-image by these criteria.  If
         # more than one image is found, Packer will fail the build (and display
@@ -156,10 +156,7 @@ builders:
       run_tags: *awstags
       run_volume_tags: *awstags
       snapshot_tags: *awstags
-      # This is necessary for security - The CI service accounts are not permitted
-      # to use AMI's from any other account, including public ones.
-      ami_users:
-        - *accountid
+      ami_groups: ["all"]  # Make resulting AMI publically accessable to all users
       ssh_username: 'fedora'
       ssh_clear_authorized_keys: true
       # N/B: Required Packer >= 1.8.0

--- a/cache_images/cloud.yml
+++ b/cache_images/cloud.yml
@@ -78,10 +78,10 @@ builders:
       instance_type: 'm5zn.metal'
       source_ami_filter:  # Will fail if >1 or no AMI found
         owners:
-            # Docs are wrong, specifying the Account ID required to make AMIs private.
-            # The Account ID is hard-coded here out of expediency, since passing in
-            # more packer args from the command-line (in Makefile) is non-trivial.
-            - &accountid '449134212816'
+            # Docs are wrong, specifying the Account ID required to search only for
+            # our own imported AMIs. The Account ID is hard-coded here out of
+            # expediency.
+            - '449134212816'
         # It's necessary to 'search' for the base-image by these criteria.  If
         # more than one image is found, Packer will fail the build (and display
         # the conflicting AMI IDs).
@@ -124,9 +124,7 @@ builders:
       run_tags: *ami_tags
       run_volume_tags: *ami_tags
       snapshot_tags: *ami_tags
-      # Also required to make AMI private
-      ami_users:
-        - *accountid
+      ami_groups: ["all"]  # Make resulting AMI publically accessable to all users
       ssh_username: 'root'
       ssh_clear_authorized_keys: true
       # N/B: Required Packer >= 1.8.0
@@ -136,8 +134,6 @@ builders:
     - <<: *fedora-aws
       name: 'fedora-netavark-aws-arm64'
       source_ami_filter:
-        owners:
-            - *accountid
         filters:
             <<: *ami_filters
             architecture: 'arm64'
@@ -154,8 +150,6 @@ builders:
     - <<: *fedora-aws
       name: 'fedora-podman-aws-arm64'
       source_ami_filter:
-        owners:
-            - *accountid
         filters:
             <<: *ami_filters
             architecture: 'arm64'

--- a/cache_images/podman_tooling.sh
+++ b/cache_images/podman_tooling.sh
@@ -36,14 +36,6 @@ export GOCACHE="${GOCACHE:-$GOPATH/cache}"
 eval $(go env | tee /dev/stderr)
 export PATH="$GOPATH/bin:$PATH"
 
-echo "Installing runtime tooling"
-lilto git clone --quiet https://github.com/containers/podman.git "$GOSRC"
-
-cd "$GOSRC" || die "Podman repo. not cloned to expected directory: '$GOSRC'"
-# Calling script already loaded lib.sh
-lilto ./hack/install_catatonit.sh
-bigto make install.tools
-
 # shellcheck disable=SC2154
 if [[ "$OS_RELEASE_ID" == "fedora" ]]; then
     if [[ $(uname -m) == "x86_64" ]]; then
@@ -55,9 +47,6 @@ if [[ "$OS_RELEASE_ID" == "fedora" ]]; then
         chmod +x /usr/local/bin/swagger
         /usr/local/bin/swagger version
     fi
-
-    # This is needed for rootless testing
-    make install.modules-load
 fi
 
 # Make pristine for other runtime usage/expectations also save a bit


### PR DESCRIPTION
Fixes: #191

On at least two occasions I can remember, users outside the containers-team have requested access to our CI VM images. Unfortunately doing this for the GCE images has some security-interest conflicts with our build automation.  However, making the AWS AMI's public is rather easy to do.  In fact it's the default unless they are specifically locked down.  Simply remove the private restrictions and allow access to `"all"` AWS groups.

Signed-off-by: Chris Evich <cevich@redhat.com>