### PR TITLE
Stop pre-installing podman utils/tools

### DIFF
--- a/cache_images/fedora_packaging.sh
+++ b/cache_images/fedora_packaging.sh
@@ -167,6 +167,13 @@ if [[ "$PACKER_BUILD_NAME" =~ prior ]]; then
     EXARG="--exclude=netavark --exclude=aardvark-dns"
 fi
 
+# Workarond: Around the time of this commit, the `criu` package
+# was found to be missing a recommends-dependency on criu-libs.
+# Until a fixed rpm lands in the Fedora repositories, manually
+# include it here.  This workaround should be removed once the
+# package is corrected (likely > 3.17.1-3).
+INSTALL_PACKAGES+=(criu-libs)
+
 # When installing during a container-build, having this present
 # will seriously screw up future dnf operations in very non-obvious ways.
 if ! ((CONTAINER)); then

--- a/cache_images/podman_tooling.sh
+++ b/cache_images/podman_tooling.sh
@@ -36,14 +36,6 @@ export GOCACHE="${GOCACHE:-$GOPATH/cache}"
 eval $(go env | tee /dev/stderr)
 export PATH="$GOPATH/bin:$PATH"
 
-echo "Installing runtime tooling"
-lilto git clone --quiet https://github.com/containers/podman.git "$GOSRC"
-
-cd "$GOSRC" || die "Podman repo. not cloned to expected directory: '$GOSRC'"
-# Calling script already loaded lib.sh
-lilto ./hack/install_catatonit.sh
-bigto make install.tools
-
 # shellcheck disable=SC2154
 if [[ "$OS_RELEASE_ID" == "fedora" ]]; then
     if [[ $(uname -m) == "x86_64" ]]; then
@@ -55,9 +47,6 @@ if [[ "$OS_RELEASE_ID" == "fedora" ]]; then
         chmod +x /usr/local/bin/swagger
         /usr/local/bin/swagger version
     fi
-
-    # This is needed for rootless testing
-    make install.modules-load
 fi
 
 # Make pristine for other runtime usage/expectations also save a bit


### PR DESCRIPTION
Commit
https://github.com/containers/podman/commit/c7827957a427c8c85c37fcb67b3d5999dd372aa7 altered the way tooling is installed for podman making it incompatible with a c/automation_images pre-install.  Several attempts were made to update podman's scripts and Makefile to de-hardcode this.  All failed and/or were too complex.  Instead, abandon the effort entirely, allowing podman to suffer any consequential runtime-install flakes or other bad behaviors.

Signed-off-by: Chris Evich <cevich@redhat.com>