### PR TITLE
Revert "Hard-code older F36/F37 kernel versions"

### DIFF
--- a/cache_images/fedora_setup.sh
+++ b/cache_images/fedora_setup.sh
@@ -41,18 +41,6 @@ fi
 
 # Only on VMs
 if ! ((CONTAINER)); then
-    # Due to https://bugzilla.redhat.com/show_bug.cgi?id=2159066 we
-    # cannot use kernels after 6.0.15 until bug is fixed.  Since there's
-    # no simple way to compare kernel versions, just hard-code what we want.
-    # TODO: Remove this entire conditional when bug is fixed
-    if [[ "$OS_RELEASE_VER" -eq 37 ]]; then
-      $SUDO dnf install -y kernel-6.0.7-301.fc37
-      $SUDO grubby --set-default /boot/vmlinuz-6.0.7-301.fc37.$(uname -m)
-    elif [[ "$OS_RELEASE_VER" -eq 36 ]]; then
-      $SUDO dnf install -y kernel-5.17.5-300.fc36
-      $SUDO grubby --set-default /boot/vmlinuz-5.17.5-300.fc36.$(uname -m)
-    fi
-
     if [[ "$PACKER_BUILD_NAME" =~ netavark ]]; then
         msg "Setting up VM for netavark testing"
         echo -e '# Added during VM Image build\nsctp' |


### PR DESCRIPTION
This reverts commit 1609b1649b037e95797e51156310ad4f90d69798.

Fedora now has kernel 6.1.5 in the repos and this version no longer has the critical bug.
