### PR TITLE
[WIP] Use github's check-suite ID for images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,7 @@ env:
     # Version of packer to use when building images
     PACKER_VERSION: &PACKER_VERSION "1.8.3"
     # Unique suffix label to use for all images produced by _this_ run (build)
-    IMG_SFX: "${CIRRUS_BUILD_ID}"
+    IMG_SFX: "${GITHUB_CHECK_SUITE_ID}"
 
 gcp_credentials: ENCRYPTED[823fdbc2fee3c27fa054ba1e9cfca084829b5e71572f1703a28e0746b1a924ee5860193f931adce197d40bf89e7027fe]
 


### PR DESCRIPTION
In order to treat image-suffixes like version-numbers, they must be both unique, and monotonically increasing from one PR to another. Unfortunately there are no such guarantees for the Cirrus Build ID values - used prior to this commit.  A number of tests and checks require the suffix value to be defined from the `.cirrus.yml` configuration.  Switch to using the `GITHUB_CHECK_SUITE_ID` which is guaranteed to be unique and ever-increasing.

Signed-off-by: Chris Evich <cevich@redhat.com>