### PR TITLE
Modify windows image to pre-create an interactive session.

### DIFF
--- a/win_images/auto_logon.ps1
+++ b/win_images/auto_logon.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = "stop"
+$username = "Administrator"
+
+# Temporary random password to allow autologon that will be replaced
+# before the instance is put into service.
+$syms = [char[]]([char]'a'..[char]'z'  `
+               + [char]'A'..[char]'Z'  `
+               + [char]'0'..[char]'9')
+$rnd = [byte[]]::new(32)
+[System.Security.Cryptography.RandomNumberGenerator]::create().
+                                                      getBytes($rnd)
+$password = ($rnd | % { $syms[$_ % $syms.length] }) -join ''
+
+$encPass = ConvertTo-SecureString $password -AsPlainText -Force
+Set-LocalUser -Name $username -Password $encPass
+
+$winLogon= "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon"
+Set-ItemProperty $winLogon "AutoAdminLogon" -Value "1" -type String 
+Set-ItemProperty $winLogon "DefaultUsername" -Value $username -type String 
+Set-ItemProperty $winLogon "DefaultPassword" -Value $password -type String
+
+# Lock the screen immediately, even though it's unattended, just in case
+Set-ItemProperty `
+    -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run `
+    -Name LockScreen -Value "rundll32.exe user32.dll,LockWorkStation" `
+    -Type String
+
+# NOTE: For now, we do not run sysprep, since initialization with reboots
+# are exceptionally slow on metal nodes, which these target to run. This
+# will lead to a duplicate machine id, which is not ideal, but allows
+# instances to start instantly. So, instead of sysprep, trigger a reset so
+# that the admin password reset, and activation rerun on boot
+& 'C:\Program Files\Amazon\EC2Launch\ec2launch' reset --block

--- a/win_images/win-server-wsl.yml
+++ b/win_images/win-server-wsl.yml
@@ -59,10 +59,12 @@ provisioners:
     inline:
       # Disable WinRM as a security precuation (cirrus launches an agent from user-data, so we don't need it)
       - Set-Service winrm -StartupType Disabled
-      # NOTE: For now, we do not run sysprep, since initialization with reboots are exceptionally slow on metal nodes, which these
-      # target to run. This will lead to a duplicate machine id, which is not ideal, but allows instances to start instantly. 
-      # So, instead of sysprep, trigger a reset so that the admin password reset, and activation rerun on boot
-      - '& ''C:/Program Files/Amazon/EC2Launch/ec2launch'' reset --block'
+      # Also disable RDP (can be enabled via user-data manually)
+      - Set-ItemProperty -Path "HKLM:\System\CurrentControlSet\Control\Terminal Server" -Name "fDenyTSConnections" -Value 1
+      - Disable-NetFirewallRule -DisplayGroup "Remote Desktop"
+  # Setup Autologon and reset, must be last, due to pw change
+  - type: powershell
+    script: '{{template_dir}}/auto_logon.ps1'
 
 
 post-processors:

--- a/win_images/win_packaging.ps1
+++ b/win_images/win_packaging.ps1
@@ -26,7 +26,8 @@ Set-ExecutionPolicy Bypass -Scope Process -Force
 iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
 # Install Git, BZ2 archive support, Go, and the MingW (GCC for Win) compiler for CGO support
-choco install -y git mingw archiver; CheckExit
+# Add pstools to workaorund sess 0 WSL bug
+choco install -y git mingw archiver psexec; CheckExit
 choco install golang --version 1.19.2 -y; CheckExit
 
 # Install WSL, and capture text output which is not normally visible


### PR DESCRIPTION
**NOTE win images produced by this PR will not be usable until the second half on the podman side (containers/podman#17160) is merged. That PR will bump the win image forward** 

### Background

Recently Microsoft switched from shipping WSL as part of each OS major version delivery stream to a common synchronized, and more current, one provided by the Windows store.  Apps in the Windows Store are sandboxed, either as UWP native apps, or as Desktop bridge/centennial apps as is the case with WSL. Calls to launch their respective executables are intercepted and redirected to setup the appropriate silos and run the true app. However these facilities expect usage from an interactive Windows session. 

In addition to user/kernel space separation, Windows has the notion of sessions (dates back to historical Windows designs that optimized around the expectation of a single user and were subsequently expanded without breaking compatibility). Since Vista, in order to harden against malware, an isolated restricted non-interactive session 0 was reserved for running system services. Interactive sessions require a user login to start (either GUI console or RDP) and count up from id 1. 

Since the Cirrus agent is ran by the EC2 agent which runs as a system service within session 0, all WSL invocations fail due to lack of support for their sandboxing facilities. 

### Description 

In short the combination prevents podman from executing correctly. To work around this problem, the image and CI process has been redesigned to automatically create an interactive session #1, and subsequent script runs proxy execution through it to allow WSL operations to function as expected. 

There is only two approaches to create an interactive session:

1. Autologon (hardcoded user password in the clear in the registry)
2. Simulated RDP client that doesnt render graphical elements but keeps the connection open

This PR goes with the first approach, using a crypto randomly generated password with each AMI creation. This password is short lived, and is replaced by the ec2 agent process during boot before the instance is made available.  This allows the "get password" of ec2 instance connect to function.

This PR also hardens remote connectivity to the Windows instances. Access can still be achieved via a manual launch by using a brief user-data script to reenable it. 



