### PR TITLE
[CI:DOCS] Resolve TODO: human-readable image-suffixes

### DIFF
--- a/ci/validate.sh
+++ b/ci/validate.sh
@@ -13,7 +13,7 @@ REPO_DIRPATH=$(realpath "$SCRIPT_DIRPATH/../")
 # shellcheck source=./lib.sh
 source "$REPO_DIRPATH/lib.sh"
 
-req_env_vars CIRRUS_PR CIRRUS_BASE_SHA
+req_env_vars CIRRUS_PR CIRRUS_BASE_SHA CIRRUS_CHANGE_TITLE
 
 # die() will add a reference to this file and line number.
 [[ "$CIRRUS_CI" == "true" ]] || \
@@ -26,26 +26,32 @@ for target in image_builder/gce.json base_images/cloud.json \
   fi
 done
 
-# Variable is defined by Cirrus-CI at runtime
-# shellcheck disable=SC2154
-if ! git diff --name-only ${CIRRUS_BASE_SHA}..HEAD | grep -q IMG_SFX; then
-  die "Every PR must include an updated IMG_SFX file.
-Simply run 'make IMG_SFX', commit the result, and re-push."
+### The following checks only apply if validating a PR
+if [[ -z "$CIRRUS_PR" ]]; then
+  echo "Not validating IMG_SFX changes outside of a PR"
+  exit 0
 fi
 
-# Verify new IMG_SFX value always sorts later than previous value.  This prevents
-# screwups due to local timezone, bad, or unset clocks, etc.
-cd $REPO_DIRPATH
-# Automation requires the date and time components sort properly
-# as if they were version-numbers regardless of distro-version component.
-new_img_ver=$(awk -F '-' '{print $1"."$2}' ./IMG_SFX)
-# TODO: Conditional checkout not needed after the PR which added IMG_SFX file.
-if git checkout ${CIRRUS_BASE_SHA} IMG_SFX; then
-  old_img_ver=$(awk -F '-' '{print $1"."$2}' ./IMG_SFX)
-  latest_img_ver=$(echo -e "$old_img_ver\n$new_img_ver" | sort -V | tail -1)
-  [[ "$latest_img_ver" == "$new_img_ver" ]] || \
-    die "Date/time stamp appears to have gone backwards! Please commit
-an 'IMG_SFX' change with a value later than '$(<IMG_SFX)'"
+# Variable is defined by Cirrus-CI at runtime
+# shellcheck disable=SC2154
+if [[ ! "$CIRRUS_CHANGE_TITLE" =~ CI:DOCS ]] && \
+   [[ ! "$CIRRUS_CHANGE_TITLE" =~ CI:TOOLING ]] && \
+   ! git diff --name-only ${CIRRUS_BASE_SHA}..HEAD | grep -q IMG_SFX; then
+
+  die "Every PR that builds images must include an updated IMG_SFX file.
+Simply run 'make IMG_SFX', commit the result, and re-push."
 else
-  warn "Could not find previous version of IMG_SFX, ignoring."
+  # IMG_SFX was modified vs PR's base-branch, confirm version moved forward
+  # shellcheck disable=SC2154
+  v_prev=$(git show ${CIRRUS_BASE_SHA}:IMG_SFX 2>&1 || true)
+  # Verify new IMG_SFX value always version-sorts later than previous value.
+  # This prevents screwups due to local timezone, bad, or unset clocks, etc.
+  new_img_ver=$(awk -F 't' '{print $1"."$2}' ./IMG_SFX | cut -dz -f1)
+  old_img_ver=$(awk -F 't' '{print $1"."$2}'<<<"$v_prev" | cut -dz -f1)
+  # Version-sorting of date/time mimics the way renovate will compare values
+  # see https://github.com/containers/automation/blob/main/renovate/defaults.json5
+  latest_img_ver=$(echo -e "$new_img_ver\n$old_img_ver" | sort -V | tail -1)
+  [[ "$latest_img_ver" == "$new_img_ver" ]] || \
+    die "Updated IMG_SFX '$(<IMG_SFX)' appears to be older than previous
+value '$v_prev'.  Please check your local clock and try again."
 fi


### PR DESCRIPTION
This conditional was required temporarily so #247 could merge.  Remove
and replace it with a version that avoids modifying any files and only
checks if `IMG_SFX` changes were made.

Depends on #247 