### PR TITLE
[CI:DOCS] Renovate management of common-lib updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,6 +50,48 @@
   // Don't leave dep. update. PRs "hanging", assign them to people.
   "assignees": ["cevich"],
 
-  // Don't build CI VM images for dep. update PRs
+  // Don't build CI VM images for dep. update PRs (by default)
   commitMessagePrefix: "[CI:DOCS]",
+
+  "regexManagers": [
+    {
+      "fileMatch": "^lib.sh$",
+      "matchStrings": ["^INSTALL_AUTOMATION_VERSION=\"(?<currentValue>.+)\""],
+      "depNameTemplate": "containers/automation",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver-coerced",
+    },
+  ],
+
+  // N/B: LAST MATCHING RULE WINS, match statems are ANDed together.
+  // https://docs.renovatebot.com/configuration-options/#packagerules
+  "packageRules": [
+    {
+      "matchManagers": ["regex"],
+      "matchFiles": ["lib.sh"],  // full-path exact-match
+      "groupName": "Automation library update",
+      // Don't wait, roll out CI VM Updates immediately
+      "schedule": ["at any time"],
+      // Override default `[CI:DOCS]`, DO build new CI VM images.
+      commitMessagePrefix: null,
+      // Frequently, library updates require adjustments to build-scripts
+      "draftPR": true,
+      "reviewers": ["cevich"],
+      "prBodyNotes": [
+// handlebar conditionals don't have logical operators, and renovate
+// does not provide an 'isMinor' template field
+"\
+{{#if isMajor}}\
+:warning: Changes are **likely** required for build-scripts \
+and/or downstream CI VM image users. Please check very carefully. :warning:\
+{{/if}}\
+{{#if isPatch}}\
+{{else}}\
+:warning: Changes *might be* required for build-scripts \
+and/or downstream CI VM image users. Please double-check. :warning:\
+{{/if}}\
+"
+      ],
+    }
+  ]
 }

--- a/lib.sh
+++ b/lib.sh
@@ -24,7 +24,7 @@ INSTALL_AUTOMATION_VERSION="4.2.1"
 PUSH_LATEST="${PUSH_LATEST:-0}"
 
 # Mask secrets in show_env_vars() from automation library
-SECRET_ENV_RE='(ACCOUNT)|(.+_JSON)|(AWS.+)|(SSH)|(PASSWORD)|(TOKEN)'
+SECRET_ENV_RE='(^PATH$)|(^BASH_FUNC)|(^_.*)|(.*PASSWORD.*)|(.*TOKEN.*)|(.*SECRET.*)|(.*ACCOUNT.*)|(.+_JSON)|(AWS.+)|(.*SSH.*)|(.*GCP.*)'
 
 # Some platforms set and make this read-only
 [[ -n "$UID" ]] || \


### PR DESCRIPTION
Often these kinds of updates require some hand-holding of the build process and/or manual build-script updates.  However, it's desirable to not allow CI VM images to get "too far" behind w/ their common-lib version.  Teach renovate how to manage it, try to build CI VM images, but mark the PRs as draft since they likely need more scrutiny.