### PR TITLE
[CI:DOCS] Minor readme update

### DIFF
--- a/import_images/README.md
+++ b/import_images/README.md
@@ -30,9 +30,16 @@ human:
 
   ```
   [default]
-  output = json
   aws_access_key_id = <Unquoted value>
   aws_secret_access_key = <Unquoted value>
+  ```
+
+  The format for `~/.aws/config` is similarly simple:
+
+  ```
+  [defaults]
+  output = json
+  region = us-east-1
   ```
 
 * Podman is installed and functional


### PR DESCRIPTION
Modern versions of the AWS cli allow all these options to exist in the `credentials` file.  But for completeness, and to add in the region default, best mention them.