### PR TITLE
Update command to install chocolatey packages

### DIFF
--- a/win_images/win-lib.ps1
+++ b/win_images/win-lib.ps1
@@ -35,7 +35,7 @@ function retryInstall {
                 $pkg = @("--version", $Matches.2, $Matches.1)
             }
 
-            choco install -y --allow-downgrade --execution-timeout=300 $pkg
+            choco upgrade $pkg -y --allow-downgrade --execution-timeout=300 --source="'https://community.chocolatey.org/api/v2'"
             if ($LASTEXITCODE -eq 0) {
                 break
             }


### PR DESCRIPTION
Changes `choco install` command to ahdere to [chocolatey scripting best practices](https://docs.chocolatey.org/en-us/choco/commands/#scripting-integration-best-practices-style-guide). 

In particular:
- use `choco upgrade` rather `choco install`
- move the package name to be the first parameter
- explicitly set choco source