### PR TITLE
[CI:DOCS] Fix test_build-push failing w/ no_build-push label

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -462,7 +462,9 @@ test_ccia_task:
 test_build-push_task:
     name: "Test build-push VM functions"
     alias: test_build-push
-    only_if: *is_pr
+    only_if: |
+        $CIRRUS_PR != '' &&
+        $CIRRUS_PR_LABELS !=~ ".*no_build-push.*"
     skip: *ci_docs_tooling
     depends_on:
         - cache_images


### PR DESCRIPTION
Previously the build-push task was much more sophisticated and able to run even if a new CI VM image was not produced.  This situation has now changed, and the testing task requires some additional "smarts" to not run when its image wasn't build.

Note: I have to set `[CI:DOCS]` on this otherwise the validate check barfs due to no `IMG_SFX` update.  I cannot update `IMG_SFX` due to a bunch of expired `timebomb()`s.  However, this change (and the `timebomb()`s) was successfully tested when it was originally part of https://github.com/containers/automation_images/pull/349