### PR TITLE
[CI:DOCS] Stop tagging during cron runs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -485,7 +485,9 @@ test_build-push_task:
 tag_latest_images_task:
     alias: tag_latest_images
     name: "Tag latest built container images."
-    only_if: $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH
+    only_if: |
+        $CIRRUS_CRON == '' &&
+        $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH
     skip: *ci_docs
     gce_instance: *ibi_vm
     env: *image_env


### PR DESCRIPTION
Previously the `tag_latest_images` was executing during the daily 'lifecycle' Cirrus-cron job.  This was unintentional, this task should only run after a merge onto the default branch.  Fix the condition.