### PR TITLE
[CI:DOCS] Add example pre-commit config

### DIFF
--- a/.codespelldict
+++ b/.codespelldict
@@ -1,0 +1,2 @@
+IMGSFX,IMG-SFX->IMG_SFX
+Dockerfile->Containerfile

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+ignore-words = .codespellignore
+dictionary = .codespelldict
+quiet-level = 3

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 */*.json
 /.cache
+.pre-commit-config.yaml

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -1,4 +1,4 @@
-# This dockerfile defines the environment for Cirrus-CI when
+# This Containerfile defines the environment for Cirrus-CI when
 # running automated checks and tests. It may also be used
 # for development/debugging or manually building most
 # Makefile targets.
@@ -13,7 +13,7 @@ ENV CIRRUS_WORKING_DIR=/var/tmp/automation_images \
     PACKER_VERSION=$PACKER_VERSION \
     CONTAINER=1
 
-# When using the dockerfile-as-ci feature of Cirrus-CI, it's unsafe
+# When using the containerfile-as-ci feature of Cirrus-CI, it's unsafe
 # to rely on COPY or ADD instructions.  See documentation for warning.
 RUN test -n "$PACKER_VERSION"
 RUN dnf update -y && \

--- a/dot_pre-commit-config.yaml.example
+++ b/dot_pre-commit-config.yaml.example
@@ -1,0 +1,43 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-symlinks
+      - id: mixed-line-ending
+      - id: no-commit-to-branch
+        args: [--branch, main]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        args: [--config, .codespellrc]
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0
+    hooks:
+      - id: forbid-binary
+        exclude: >
+          (?x)^(
+            get_ci_vm/good_repo_test/dot_git.tar.gz
+          )$
+      - id: script-must-have-extension
+      - id: shellcheck
+        # These come from ci/shellcheck.sh
+        args:
+            - --color=always
+            - --format=tty
+            - --shell=bash
+            - --external-sources
+            - --enable=add-default-case,avoid-nullary-conditions,check-unassigned-uppercase
+            - --exclude=SC2046,SC2034,SC2090,SC2064
+            - --wiki-link-count=0
+            - --severity=warning
+  - repo: https://github.com/containers/automation_images.git
+    rev: 2e5a2acfe21cc4b13511b453733b8875e592ad9c
+    hooks:
+      - id: check-imgsfx

--- a/imgts/lib_entrypoint.sh
+++ b/imgts/lib_entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 RED="\e[1;31m"
 YEL="\e[1;33m"
 NOR="\e[0m"
-SENTINEL="__unknown__"  # default set in dockerfile
+SENTINEL="__unknown__"  # default set in Containerfile
 # Disable all input prompts
 # https://cloud.google.com/sdk/docs/scripting-gcloud
 GCLOUD="gcloud --quiet"


### PR DESCRIPTION
Add suggested/example `pre-commit` configuration for this repo. To use as-is, simply symlink to `.pre-commit-config.yaml`.  Otherwise it can be a basis for a custom configuration.

Also include codespell config w/ repo-specific dictionary extension.

Ref: https://github.com/containers/automation_images/pull/364