### PR TITLE
[CI:DOCS] Reformat renovate config + other minor updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,20 +1,12 @@
 /*
-   Renovate is a service similar to GitHub Dependabot, but with
-   (fantastically) more configuration options.  So many options
-   in fact, if you're new I recommend glossing over this cheat-sheet
-   prior to the official documentation:
+   Renovate is a service similar to GitHub Dependabot.
 
-   https://www.augmentedmind.de/2021/07/25/renovate-bot-cheat-sheet
-
-   Configuration Update/Change Procedure:
-     1. Make changes
-     2. Manually validate changes (from repo-root):
+   Please Manually validate any changes to this file with:
 
         podman run -it \
             -v ./.github/renovate.json5:/usr/src/app/renovate.json5:z \
-            docker.io/renovate/renovate:latest \
+            ghcr.io/renovatebot/renovate:latest \
             renovate-config-validator
-     3. Commit.
 
    Configuration Reference:
    https://docs.renovatebot.com/configuration-options/
@@ -22,11 +14,9 @@
    Monitoring Dashboard:
    https://app.renovatebot.com/dashboard#github/containers
 
-   Note: The Renovate bot will create/manage it's business on
-         branches named 'renovate/*'.  Otherwise, and by
-         default, the only the copy of this file that matters
-         is the one on the `main` branch.  No other branches
-         will be monitored or touched in any way.
+   Note: The Renovate bot will create/manage its business on
+         branches named 'renovate/*'.  The only copy of this
+         file that matters is the one on the `main` branch.
 */
 
 {
@@ -44,55 +34,45 @@
     // This repo builds images, don't try to manage them.
     "docker:disable"
   ],
-  /*************************************************
-   *** Repository-specific configuration options ***
-   *************************************************/
-  // Don't leave dep. update. PRs "hanging", assign them to people.
-  "assignees": ["cevich"],
 
   // Don't build CI VM images for dep. update PRs (by default)
-  commitMessagePrefix: "[CI:DOCS]",
+  "commitMessagePrefix": "[CI:DOCS]",
 
-  "regexManagers": [
+  "customManagers": [
+    // Manage updates to the common automation library version
     {
+      "customType": "regex",
       "fileMatch": "^lib.sh$",
       "matchStrings": ["^INSTALL_AUTOMATION_VERSION=\"(?<currentValue>.+)\""],
       "depNameTemplate": "containers/automation",
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "semver-coerced",
       // "v" included in tag, but should not be used in lib.sh
-      "extractVersionTemplate": "v(?<version>.+)",
-    },
+      "extractVersionTemplate": "^v(?<version>.+)$"
+    }
   ],
 
   // N/B: LAST MATCHING RULE WINS, match statems are ANDed together.
-  // https://docs.renovatebot.com/configuration-options/#packagerules
   "packageRules": [
+    // When automation library version updated, full CI VM image build
+    // is needed, along with some other overrides not required in
+    // (for example) github-action updates.
     {
-      "matchManagers": ["regex"],
-      "matchFiles": ["lib.sh"],  // full-path exact-match
-      // Don't wait, roll out CI VM Updates immediately
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["^lib.sh$"],
       "schedule": ["at any time"],
-      // Override default `[CI:DOCS]`, DO build new CI VM images.
-      commitMessagePrefix: null,
-      // Frequently, library updates require adjustments to build-scripts
+      "commitMessagePrefix": null,
       "draftPR": true,
-      "reviewers": ["cevich"],
       "prBodyNotes": [
-// handlebar conditionals don't have logical operators, and renovate
-// does not provide an 'isMinor' template field
-"\
+        "\
 {{#if isMajor}}\
-:warning: Changes are **likely** required for build-scripts \
-and/or downstream CI VM image users. Please check very carefully. :warning:\
-{{/if}}\
-{{#if isPatch}}\
+:warning: Changes are **likely** required for build-scripts and/or downstream CI VM \
+image users. Please check very carefully. :warning:\
 {{else}}\
-:warning: Changes *might be* required for build-scripts \
-and/or downstream CI VM image users. Please double-check. :warning:\
-{{/if}}\
-"
-      ],
+:warning: Changes may be required for build-scripts and/or downstream CI VM \
+image users. Please double-check. :warning:\
+{{/if}}"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Previously the Renovate configuration was using an older format no longer supported by the bot.  Apply automatic fixes proposed by the bot, re-adding/adjusting the old comments as needed.

Also:

* Drop automatic assignment of Renovate PRs to `cevich`
* Reference the GHCR registry container image
* Simplify CI VM update warning message conditions & text.