### PR TITLE
[CI:DOCS] Fix renovate updating lib.sh

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,7 +43,7 @@
     {
       "customType": "regex",
       "fileMatch": "^lib.sh$",
-      "matchStrings": ["^INSTALL_AUTOMATION_VERSION=\"(?<currentValue>.+)\""],
+      "matchStrings": ["INSTALL_AUTOMATION_VERSION=\"(?<currentValue>.+)\""],
       "depNameTemplate": "containers/automation",
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "semver-coerced",
@@ -59,7 +59,7 @@
     // (for example) github-action updates.
     {
       "matchManagers": ["custom.regex"],
-      "matchFileNames": ["^lib.sh$"],
+      "matchFileNames": ["lib.sh"],
       "schedule": ["at any time"],
       "commitMessagePrefix": null,
       "draftPR": true,


### PR DESCRIPTION
Previously Renovate was failing in a multi-line search for an anchored pattern in `lib.sh`.  This resulted in it completely ignoring the custom regex manager for that file, as observed in the debug logs.  Fix this by removing the regex anchors.

Also remove the filename anchors referenced in the `lib.sh` package rule as they're unnecessary.