### PR TITLE
[CI:DOCS] Retire oversight of dnsname project 

### DIFF
--- a/gcpprojects.txt
+++ b/gcpprojects.txt
@@ -1,6 +1,7 @@
-# This is a listing of GCP Project IDs which use images produced by
-# this repo.  It's used by the "Orphan VMs" github action to monitor
-# for any leftover/lost VMs.
+# This is a listing of Google Cloud Platform Project IDs for
+# orphan VM monitoring and possibly other automation tasks.
+# Note: CI VM images produced by this repo are all stored within
+# the libpod-218412 project (in addition to some AWS EC2)
 buildah
 conmon-222014
 containers-build-source-image

--- a/gcpprojects.txt
+++ b/gcpprojects.txt
@@ -4,7 +4,6 @@
 buildah
 conmon-222014
 containers-build-source-image
-dnsname-8675309
 libpod-218412
 netavark-2021
 oci-seccomp-bpf-hook


### PR DESCRIPTION
This github repo has been archived, CI disabled, and the GCE project
deleted.  Stop tracking it in automation.

Also update the comment in the file.