### PR TITLE
remove udica project

### DIFF
--- a/gcpprojects.txt
+++ b/gcpprojects.txt
@@ -10,4 +10,3 @@ netavark-2021
 oci-seccomp-bpf-hook
 skopeo
 storage-240716
-udica-247612


### PR DESCRIPTION
I requested a removal of the GCP project internally since cirrus CI will shut down and we do not maintain udica.

To ensure the automation keeps working for now until June drop the project from this list as suggested by Chris.